### PR TITLE
Change Zabbix Sender with Python Zabbix Library 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,4 @@
-# zabbix-emc-unity
-Python script for monitoring EMC Unity storages
+I have modified the code to utilize Pyzabbix for sending data to Zabbix, replacing the previous use of Zabbix sender. Additionally, this updated code incorporates internal authentication mechanisms instead of relying on Zabbix parameters for data retrieval.
+zabbix-emc-unity
 
-
-For succesfull work of script need installed python3, zabbix-sender.
-
-In template "Template EMC Unity REST-API" in section "Macros" need set these macros:
-- {$API_USER}
-- {$API_PASSWORD}
-- {$API_PORT}
-- {$SUBSCRIBED_PERCENT}
-- {$USED_PERCENT}
-
-In agent configuration file, **/etc/zabbix/zabbix_agentd.conf** must be set parameter **ServerActive=xxx.xxx.xxx.xxx**
-
-Scirpt must be copied to zabbix-server or zabbix-proxy, depending on what the torage is being monitored.
-
-
-- In Linux-console on zabbix-server or zabbix-proxy need run this command to make discovery. Script must return value 0 in case of success.
-```bash
-./unity_get_state.py --api_ip=xxx.xxx.xxx.xxx --api_port=443 --api_user=username_on_storagedevice --api_password='password' --storage_name="storage-name_in_zabbix" --discovery
-```
-- On zabbix proxy or on zabbix servers need run **zabbix_proxy -R config_cache_reload** (zabbix_server -R config_cache_reload)
-
-- In Linux-console on zabbix-server or zabbix-proxy need run this command to get value of metrics. Scripts must return value 0 in case of success.
-```bash
-./unity_get_stateNEW.py --api_ip=xxx.xxx.xxx.xxx --api_port=443 --api_user=username_on_storagedevice --api_password='password' --storage_name="storage-name_in_zabbix" --status
-```
-If you have executed this script from console from user root or from another user, please check access permission on file **/tmp/unity_state.log**. It must be allow read, write to user zabbix.
-
-- Return code 1 or 2 is zabbix_sender return code. Read here - https://www.zabbix.com/documentation/4.4/manpages/zabbix_sender
+Python script designed for monitoring EMC Unity storages

--- a/Template EMC Unity REST-API.xml
+++ b/Template EMC Unity REST-API.xml
@@ -1,4591 +1,1075 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<zabbix_export>
-    <version>4.0</version>
-    <date>2019-10-16T08:23:07Z</date>
-    <groups>
-        <group>
-            <name>Templates</name>
-        </group>
-    </groups>
-    <templates>
-        <template>
-            <template>Template EMC Unity REST-API v3</template>
-            <name>Template EMC Unity REST-API v3</name>
-            <description/>
-            <groups>
-                <group>
-                    <name>Templates</name>
-                </group>
-            </groups>
-            <applications>
-                <application>
-                    <name>BBU</name>
-                </application>
-                <application>
-                    <name>BBU health</name>
-                </application>
-                <application>
-                    <name>DAE health</name>
-                </application>
-                <application>
-                    <name>Disk</name>
-                </application>
-                <application>
-                    <name>Disk health</name>
-                </application>
-                <application>
-                    <name>DPE health</name>
-                </application>
-                <application>
-                    <name>Eth</name>
-                </application>
-                <application>
-                    <name>Eth health</name>
-                </application>
-                <application>
-                    <name>FAN</name>
-                </application>
-                <application>
-                    <name>FAN health</name>
-                </application>
-                <application>
-                    <name>FC health</name>
-                </application>
-                <application>
-                    <name>FC Port</name>
-                </application>
-                <application>
-                    <name>get_data_from_script</name>
-                </application>
-                <application>
-                    <name>I/O Module health</name>
-                </application>
-                <application>
-                    <name>Internal</name>
-                </application>
-                <application>
-                    <name>LCC health</name>
-                </application>
-                <application>
-                    <name>LUN</name>
-                </application>
-                <application>
-                    <name>LUN health</name>
-                </application>
-                <application>
-                    <name>MemoryModule</name>
-                </application>
-                <application>
-                    <name>MemoryModule health</name>
-                </application>
-                <application>
-                    <name>Pool</name>
-                </application>
-                <application>
-                    <name>Pool health</name>
-                </application>
-                <application>
-                    <name>PSU</name>
-                </application>
-                <application>
-                    <name>PSU health</name>
-                </application>
-                <application>
-                    <name>SAS</name>
-                </application>
-                <application>
-                    <name>SAS health</name>
-                </application>
-                <application>
-                    <name>SSC health</name>
-                </application>
-                <application>
-                    <name>SSD health</name>
-                </application>
-                <application>
-                    <name>StorageProcessor health</name>
-                </application>
-                <application>
-                    <name>Uncommitted Port health</name>
-                </application>
-            </applications>
-            <items>
-                <item>
-                    <name>get discovery</name>
-                    <type>10</type>
-                    <snmp_community/>
-                    <snmp_oid/>
-                    <key>unity_get_state.py[&quot;--api_ip={HOST.IP}&quot;,&quot;--api_port={$API_PORT}&quot;,&quot;--api_user={$API_USER}&quot;,&quot;--api_password={$API_PASSWORD}&quot;,&quot;--storage_name={HOST.NAME}&quot;,&quot;--discovery&quot;]</key>
-                    <delay>15m</delay>
-                    <history>90d</history>
-                    <trends>365d</trends>
-                    <status>0</status>
-                    <value_type>3</value_type>
-                    <allowed_hosts/>
-                    <units/>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <description/>
-                    <inventory_link>0</inventory_link>
-                    <applications>
-                        <application>
-                            <name>get_data_from_script</name>
-                        </application>
-                    </applications>
-                    <valuemap/>
-                    <logtimefmt/>
-                    <preprocessing/>
-                    <jmx_endpoint/>
-                    <timeout>3s</timeout>
-                    <url/>
-                    <query_fields/>
-                    <posts/>
-                    <status_codes>200</status_codes>
-                    <follow_redirects>1</follow_redirects>
-                    <post_type>0</post_type>
-                    <http_proxy/>
-                    <headers/>
-                    <retrieve_mode>0</retrieve_mode>
-                    <request_method>1</request_method>
-                    <output_format>0</output_format>
-                    <allow_traps>0</allow_traps>
-                    <ssl_cert_file/>
-                    <ssl_key_file/>
-                    <ssl_key_password/>
-                    <verify_peer>0</verify_peer>
-                    <verify_host>0</verify_host>
-                    <master_item/>
-                </item>
-                <item>
-                    <name>get health state</name>
-                    <type>10</type>
-                    <snmp_community/>
-                    <snmp_oid/>
-                    <key>unity_get_state.py[&quot;--api_ip={HOST.IP}&quot;,&quot;--api_port={$API_PORT}&quot;,&quot;--api_user={$API_USER}&quot;,&quot;--api_password={$API_PASSWORD}&quot;,&quot;--storage_name={HOST.NAME}&quot;,&quot;--status&quot;]</key>
-                    <delay>3m</delay>
-                    <history>90d</history>
-                    <trends>365d</trends>
-                    <status>0</status>
-                    <value_type>3</value_type>
-                    <allowed_hosts/>
-                    <units/>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <description/>
-                    <inventory_link>0</inventory_link>
-                    <applications>
-                        <application>
-                            <name>get_data_from_script</name>
-                        </application>
-                    </applications>
-                    <valuemap/>
-                    <logtimefmt/>
-                    <preprocessing/>
-                    <jmx_endpoint/>
-                    <timeout>3s</timeout>
-                    <url/>
-                    <query_fields/>
-                    <posts/>
-                    <status_codes>200</status_codes>
-                    <follow_redirects>1</follow_redirects>
-                    <post_type>0</post_type>
-                    <http_proxy/>
-                    <headers/>
-                    <retrieve_mode>0</retrieve_mode>
-                    <request_method>1</request_method>
-                    <output_format>0</output_format>
-                    <allow_traps>0</allow_traps>
-                    <ssl_cert_file/>
-                    <ssl_key_file/>
-                    <ssl_key_password/>
-                    <verify_peer>0</verify_peer>
-                    <verify_host>0</verify_host>
-                    <master_item/>
-                </item>
-                <item>
-                    <name>Count of unsupported items</name>
-                    <type>5</type>
-                    <snmp_community/>
-                    <snmp_oid/>
-                    <key>zabbix[host,,items_unsupported]</key>
-                    <delay>5m</delay>
-                    <history>90d</history>
-                    <trends>365d</trends>
-                    <status>0</status>
-                    <value_type>3</value_type>
-                    <allowed_hosts/>
-                    <units/>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <description/>
-                    <inventory_link>0</inventory_link>
-                    <applications>
-                        <application>
-                            <name>Internal</name>
-                        </application>
-                    </applications>
-                    <valuemap/>
-                    <logtimefmt/>
-                    <preprocessing/>
-                    <jmx_endpoint/>
-                    <timeout>3s</timeout>
-                    <url/>
-                    <query_fields/>
-                    <posts/>
-                    <status_codes>200</status_codes>
-                    <follow_redirects>1</follow_redirects>
-                    <post_type>0</post_type>
-                    <http_proxy/>
-                    <headers/>
-                    <retrieve_mode>0</retrieve_mode>
-                    <request_method>0</request_method>
-                    <output_format>0</output_format>
-                    <allow_traps>0</allow_traps>
-                    <ssl_cert_file/>
-                    <ssl_key_file/>
-                    <ssl_key_password/>
-                    <verify_peer>0</verify_peer>
-                    <verify_host>0</verify_host>
-                    <master_item/>
-                </item>
-            </items>
-            <discovery_rules>
-                <discovery_rule>
-                    <name>BBU</name>
-                    <type>2</type>
-                    <snmp_community/>
-                    <snmp_oid/>
-                    <key>battery</key>
-                    <delay>0</delay>
-                    <status>0</status>
-                    <allowed_hosts/>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <filter>
-                        <evaltype>0</evaltype>
-                        <formula/>
-                        <conditions/>
-                    </filter>
-                    <lifetime>1d</lifetime>
-                    <description/>
-                    <item_prototypes>
-                        <item_prototype>
-                            <name>Health status of BBU &quot;{#ID}&quot;</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>health.battery.[{#ID}]</key>
-                            <delay>0</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>BBU health</name>
-                                </application>
-                            </applications>
-                            <valuemap>
-                                <name>Unity_Health_Status</name>
-                            </valuemap>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <timeout>3s</timeout>
-                            <url/>
-                            <query_fields/>
-                            <posts/>
-                            <status_codes>200</status_codes>
-                            <follow_redirects>1</follow_redirects>
-                            <post_type>0</post_type>
-                            <http_proxy/>
-                            <headers/>
-                            <retrieve_mode>0</retrieve_mode>
-                            <request_method>1</request_method>
-                            <output_format>0</output_format>
-                            <allow_traps>0</allow_traps>
-                            <ssl_cert_file/>
-                            <ssl_key_file/>
-                            <ssl_key_password/>
-                            <verify_peer>0</verify_peer>
-                            <verify_host>0</verify_host>
-                            <application_prototypes/>
-                            <master_item/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>Running status of BBU &quot;{#ID}&quot;</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>running.battery.[{#ID}]</key>
-                            <delay>0</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>BBU</name>
-                                </application>
-                            </applications>
-                            <valuemap>
-                                <name>Unity_Running_Status</name>
-                            </valuemap>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <timeout>3s</timeout>
-                            <url/>
-                            <query_fields/>
-                            <posts/>
-                            <status_codes>200</status_codes>
-                            <follow_redirects>1</follow_redirects>
-                            <post_type>0</post_type>
-                            <http_proxy/>
-                            <headers/>
-                            <retrieve_mode>0</retrieve_mode>
-                            <request_method>1</request_method>
-                            <output_format>0</output_format>
-                            <allow_traps>0</allow_traps>
-                            <ssl_cert_file/>
-                            <ssl_key_file/>
-                            <ssl_key_password/>
-                            <verify_peer>0</verify_peer>
-                            <verify_host>0</verify_host>
-                            <application_prototypes/>
-                            <master_item/>
-                        </item_prototype>
-                    </item_prototypes>
-                    <trigger_prototypes>
-                        <trigger_prototype>
-                            <expression>{Template EMC Unity REST-API v3:health.battery.[{#ID}].last()}&lt;&gt;5</expression>
-                            <recovery_mode>0</recovery_mode>
-                            <recovery_expression/>
-                            <name>{HOST.NAME} -&gt; BBU &quot;{#ID}&quot; health status is {ITEM.VALUE}</name>
-                            <correlation_mode>0</correlation_mode>
-                            <correlation_tag/>
-                            <url/>
-                            <status>0</status>
-                            <priority>4</priority>
-                            <description/>
-                            <type>0</type>
-                            <manual_close>0</manual_close>
-                            <dependencies/>
-                            <tags/>
-                        </trigger_prototype>
-                        <trigger_prototype>
-                            <expression>{Template EMC Unity REST-API v3:running.battery.[{#ID}].last()}&lt;&gt;8</expression>
-                            <recovery_mode>0</recovery_mode>
-                            <recovery_expression/>
-                            <name>{HOST.NAME} -&gt; BBU &quot;{#ID}&quot; running status is {ITEM.VALUE}</name>
-                            <correlation_mode>0</correlation_mode>
-                            <correlation_tag/>
-                            <url/>
-                            <status>0</status>
-                            <priority>4</priority>
-                            <description/>
-                            <type>0</type>
-                            <manual_close>0</manual_close>
-                            <dependencies/>
-                            <tags/>
-                        </trigger_prototype>
-                    </trigger_prototypes>
-                    <graph_prototypes/>
-                    <host_prototypes/>
-                    <jmx_endpoint/>
-                    <timeout>3s</timeout>
-                    <url/>
-                    <query_fields/>
-                    <posts/>
-                    <status_codes>200</status_codes>
-                    <follow_redirects>1</follow_redirects>
-                    <post_type>0</post_type>
-                    <http_proxy/>
-                    <headers/>
-                    <retrieve_mode>0</retrieve_mode>
-                    <request_method>1</request_method>
-                    <allow_traps>0</allow_traps>
-                    <ssl_cert_file/>
-                    <ssl_key_file/>
-                    <ssl_key_password/>
-                    <verify_peer>0</verify_peer>
-                    <verify_host>0</verify_host>
-                </discovery_rule>
-                <discovery_rule>
-                    <name>Disk Array Enclosure (DAE)</name>
-                    <type>2</type>
-                    <snmp_community/>
-                    <snmp_oid/>
-                    <key>dae</key>
-                    <delay>0</delay>
-                    <status>0</status>
-                    <allowed_hosts/>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <filter>
-                        <evaltype>0</evaltype>
-                        <formula/>
-                        <conditions/>
-                    </filter>
-                    <lifetime>1d</lifetime>
-                    <description/>
-                    <item_prototypes>
-                        <item_prototype>
-                            <name>Health status of DAE &quot;{#ID}&quot;</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>health.dae.[{#ID}]</key>
-                            <delay>0</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>DAE health</name>
-                                </application>
-                            </applications>
-                            <valuemap>
-                                <name>Unity_Health_Status</name>
-                            </valuemap>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <timeout>3s</timeout>
-                            <url/>
-                            <query_fields/>
-                            <posts/>
-                            <status_codes>200</status_codes>
-                            <follow_redirects>1</follow_redirects>
-                            <post_type>0</post_type>
-                            <http_proxy/>
-                            <headers/>
-                            <retrieve_mode>0</retrieve_mode>
-                            <request_method>1</request_method>
-                            <output_format>0</output_format>
-                            <allow_traps>0</allow_traps>
-                            <ssl_cert_file/>
-                            <ssl_key_file/>
-                            <ssl_key_password/>
-                            <verify_peer>0</verify_peer>
-                            <verify_host>0</verify_host>
-                            <application_prototypes/>
-                            <master_item/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>Running status of DAE &quot;{#ID}&quot;</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>running.dae.[{#ID}]</key>
-                            <delay>0</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>DAE health</name>
-                                </application>
-                            </applications>
-                            <valuemap>
-                                <name>Unity_Running_Status</name>
-                            </valuemap>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <timeout>3s</timeout>
-                            <url/>
-                            <query_fields/>
-                            <posts/>
-                            <status_codes>200</status_codes>
-                            <follow_redirects>1</follow_redirects>
-                            <post_type>0</post_type>
-                            <http_proxy/>
-                            <headers/>
-                            <retrieve_mode>0</retrieve_mode>
-                            <request_method>1</request_method>
-                            <output_format>0</output_format>
-                            <allow_traps>0</allow_traps>
-                            <ssl_cert_file/>
-                            <ssl_key_file/>
-                            <ssl_key_password/>
-                            <verify_peer>0</verify_peer>
-                            <verify_host>0</verify_host>
-                            <application_prototypes/>
-                            <master_item/>
-                        </item_prototype>
-                    </item_prototypes>
-                    <trigger_prototypes>
-                        <trigger_prototype>
-                            <expression>{Template EMC Unity REST-API v3:health.dae.[{#ID}].last()}&lt;&gt;5</expression>
-                            <recovery_mode>0</recovery_mode>
-                            <recovery_expression/>
-                            <name>{HOST.NAME} -&gt; DAE &quot;{#ID}&quot; health status is {ITEM.VALUE}</name>
-                            <correlation_mode>0</correlation_mode>
-                            <correlation_tag/>
-                            <url/>
-                            <status>0</status>
-                            <priority>4</priority>
-                            <description/>
-                            <type>0</type>
-                            <manual_close>0</manual_close>
-                            <dependencies/>
-                            <tags/>
-                        </trigger_prototype>
-                        <trigger_prototype>
-                            <expression>{Template EMC Unity REST-API v3:running.dae.[{#ID}].last()}&lt;&gt;8</expression>
-                            <recovery_mode>0</recovery_mode>
-                            <recovery_expression/>
-                            <name>{HOST.NAME} -&gt; DAE &quot;{#ID}&quot; running status is {ITEM.VALUE}</name>
-                            <correlation_mode>0</correlation_mode>
-                            <correlation_tag/>
-                            <url/>
-                            <status>0</status>
-                            <priority>4</priority>
-                            <description/>
-                            <type>0</type>
-                            <manual_close>0</manual_close>
-                            <dependencies/>
-                            <tags/>
-                        </trigger_prototype>
-                    </trigger_prototypes>
-                    <graph_prototypes/>
-                    <host_prototypes/>
-                    <jmx_endpoint/>
-                    <timeout>3s</timeout>
-                    <url/>
-                    <query_fields/>
-                    <posts/>
-                    <status_codes>200</status_codes>
-                    <follow_redirects>1</follow_redirects>
-                    <post_type>0</post_type>
-                    <http_proxy/>
-                    <headers/>
-                    <retrieve_mode>0</retrieve_mode>
-                    <request_method>1</request_method>
-                    <allow_traps>0</allow_traps>
-                    <ssl_cert_file/>
-                    <ssl_key_file/>
-                    <ssl_key_password/>
-                    <verify_peer>0</verify_peer>
-                    <verify_host>0</verify_host>
-                </discovery_rule>
-                <discovery_rule>
-                    <name>Disk</name>
-                    <type>2</type>
-                    <snmp_community/>
-                    <snmp_oid/>
-                    <key>disk</key>
-                    <delay>0</delay>
-                    <status>0</status>
-                    <allowed_hosts/>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <filter>
-                        <evaltype>0</evaltype>
-                        <formula/>
-                        <conditions/>
-                    </filter>
-                    <lifetime>1d</lifetime>
-                    <description/>
-                    <item_prototypes>
-                        <item_prototype>
-                            <name>Health status of disk &quot;{#ID}&quot;</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>health.disk.[{#ID}]</key>
-                            <delay>0</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>Disk health</name>
-                                </application>
-                            </applications>
-                            <valuemap>
-                                <name>Unity_Health_Status</name>
-                            </valuemap>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <timeout>3s</timeout>
-                            <url/>
-                            <query_fields/>
-                            <posts/>
-                            <status_codes>200</status_codes>
-                            <follow_redirects>1</follow_redirects>
-                            <post_type>0</post_type>
-                            <http_proxy/>
-                            <headers/>
-                            <retrieve_mode>0</retrieve_mode>
-                            <request_method>1</request_method>
-                            <output_format>0</output_format>
-                            <allow_traps>0</allow_traps>
-                            <ssl_cert_file/>
-                            <ssl_key_file/>
-                            <ssl_key_password/>
-                            <verify_peer>0</verify_peer>
-                            <verify_host>0</verify_host>
-                            <application_prototypes/>
-                            <master_item/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>Running status of disk &quot;{#ID}&quot;</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>running.disk.[{#ID}]</key>
-                            <delay>0</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>Disk</name>
-                                </application>
-                            </applications>
-                            <valuemap>
-                                <name>Unity_Running_Status</name>
-                            </valuemap>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <timeout>3s</timeout>
-                            <url/>
-                            <query_fields/>
-                            <posts/>
-                            <status_codes>200</status_codes>
-                            <follow_redirects>1</follow_redirects>
-                            <post_type>0</post_type>
-                            <http_proxy/>
-                            <headers/>
-                            <retrieve_mode>0</retrieve_mode>
-                            <request_method>1</request_method>
-                            <output_format>0</output_format>
-                            <allow_traps>0</allow_traps>
-                            <ssl_cert_file/>
-                            <ssl_key_file/>
-                            <ssl_key_password/>
-                            <verify_peer>0</verify_peer>
-                            <verify_host>0</verify_host>
-                            <application_prototypes/>
-                            <master_item/>
-                        </item_prototype>
-                    </item_prototypes>
-                    <trigger_prototypes>
-                        <trigger_prototype>
-                            <expression>{Template EMC Unity REST-API v3:health.disk.[{#ID}].last()}&lt;&gt;5</expression>
-                            <recovery_mode>0</recovery_mode>
-                            <recovery_expression/>
-                            <name>{HOST.NAME} -&gt; Hard disk &quot;{#ID}&quot; health status is {ITEM.VALUE}</name>
-                            <correlation_mode>0</correlation_mode>
-                            <correlation_tag/>
-                            <url/>
-                            <status>0</status>
-                            <priority>4</priority>
-                            <description/>
-                            <type>0</type>
-                            <manual_close>0</manual_close>
-                            <dependencies/>
-                            <tags/>
-                        </trigger_prototype>
-                        <trigger_prototype>
-                            <expression>({TRIGGER.VALUE}=0 and {Template EMC Unity REST-API v3:running.disk.[{#ID}].last()}=6 and {Template EMC Unity REST-API v3:running.disk.[{#ID}].change()}=1) or ({TRIGGER.VALUE}=1 and {Template EMC Unity REST-API v3:running.disk.[{#ID}].change()}=0) or  ({TRIGGER.VALUE}=1 and {Template EMC Unity REST-API v3:running.disk.[{#ID}].last()}&lt;&gt;8 and {Template EMC Unity REST-API v3:running.disk.[{#ID}].change()}=1)</expression>
-                            <recovery_mode>0</recovery_mode>
-                            <recovery_expression/>
-                            <name>{HOST.NAME} -&gt; Hard disk &quot;{#ID}&quot; running status is {ITEM.VALUE}</name>
-                            <correlation_mode>0</correlation_mode>
-                            <correlation_tag/>
-                            <url/>
-                            <status>0</status>
-                            <priority>4</priority>
-                            <description/>
-                            <type>0</type>
-                            <manual_close>0</manual_close>
-                            <dependencies/>
-                            <tags/>
-                        </trigger_prototype>
-                    </trigger_prototypes>
-                    <graph_prototypes/>
-                    <host_prototypes/>
-                    <jmx_endpoint/>
-                    <timeout>3s</timeout>
-                    <url/>
-                    <query_fields/>
-                    <posts/>
-                    <status_codes>200</status_codes>
-                    <follow_redirects>1</follow_redirects>
-                    <post_type>0</post_type>
-                    <http_proxy/>
-                    <headers/>
-                    <retrieve_mode>0</retrieve_mode>
-                    <request_method>1</request_method>
-                    <allow_traps>0</allow_traps>
-                    <ssl_cert_file/>
-                    <ssl_key_file/>
-                    <ssl_key_password/>
-                    <verify_peer>0</verify_peer>
-                    <verify_host>0</verify_host>
-                </discovery_rule>
-                <discovery_rule>
-                    <name>Disk Processor Enclosures (DPE)</name>
-                    <type>2</type>
-                    <snmp_community/>
-                    <snmp_oid/>
-                    <key>dpe</key>
-                    <delay>0</delay>
-                    <status>0</status>
-                    <allowed_hosts/>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <filter>
-                        <evaltype>0</evaltype>
-                        <formula/>
-                        <conditions/>
-                    </filter>
-                    <lifetime>1d</lifetime>
-                    <description/>
-                    <item_prototypes>
-                        <item_prototype>
-                            <name>Health status of DPE &quot;{#ID}&quot;</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>health.dpe.[{#ID}]</key>
-                            <delay>0</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>DPE health</name>
-                                </application>
-                            </applications>
-                            <valuemap>
-                                <name>Unity_Health_Status</name>
-                            </valuemap>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <timeout>3s</timeout>
-                            <url/>
-                            <query_fields/>
-                            <posts/>
-                            <status_codes>200</status_codes>
-                            <follow_redirects>1</follow_redirects>
-                            <post_type>0</post_type>
-                            <http_proxy/>
-                            <headers/>
-                            <retrieve_mode>0</retrieve_mode>
-                            <request_method>1</request_method>
-                            <output_format>0</output_format>
-                            <allow_traps>0</allow_traps>
-                            <ssl_cert_file/>
-                            <ssl_key_file/>
-                            <ssl_key_password/>
-                            <verify_peer>0</verify_peer>
-                            <verify_host>0</verify_host>
-                            <application_prototypes/>
-                            <master_item/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>Running status of DPE &quot;{#ID}&quot;</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>running.dpe.[{#ID}]</key>
-                            <delay>0</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>DPE health</name>
-                                </application>
-                            </applications>
-                            <valuemap>
-                                <name>Unity_Running_Status</name>
-                            </valuemap>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <timeout>3s</timeout>
-                            <url/>
-                            <query_fields/>
-                            <posts/>
-                            <status_codes>200</status_codes>
-                            <follow_redirects>1</follow_redirects>
-                            <post_type>0</post_type>
-                            <http_proxy/>
-                            <headers/>
-                            <retrieve_mode>0</retrieve_mode>
-                            <request_method>1</request_method>
-                            <output_format>0</output_format>
-                            <allow_traps>0</allow_traps>
-                            <ssl_cert_file/>
-                            <ssl_key_file/>
-                            <ssl_key_password/>
-                            <verify_peer>0</verify_peer>
-                            <verify_host>0</verify_host>
-                            <application_prototypes/>
-                            <master_item/>
-                        </item_prototype>
-                    </item_prototypes>
-                    <trigger_prototypes>
-                        <trigger_prototype>
-                            <expression>{Template EMC Unity REST-API v3:health.dpe.[{#ID}].last()}&lt;&gt;5</expression>
-                            <recovery_mode>0</recovery_mode>
-                            <recovery_expression/>
-                            <name>{HOST.NAME} -&gt; DPE &quot;{#ID}&quot; health status is {ITEM.VALUE}</name>
-                            <correlation_mode>0</correlation_mode>
-                            <correlation_tag/>
-                            <url/>
-                            <status>0</status>
-                            <priority>4</priority>
-                            <description/>
-                            <type>0</type>
-                            <manual_close>0</manual_close>
-                            <dependencies/>
-                            <tags/>
-                        </trigger_prototype>
-                        <trigger_prototype>
-                            <expression>{Template EMC Unity REST-API v3:running.dpe.[{#ID}].last()}&lt;&gt;8</expression>
-                            <recovery_mode>0</recovery_mode>
-                            <recovery_expression/>
-                            <name>{HOST.NAME} -&gt; DPE &quot;{#ID}&quot; running status is {ITEM.VALUE}</name>
-                            <correlation_mode>0</correlation_mode>
-                            <correlation_tag/>
-                            <url/>
-                            <status>0</status>
-                            <priority>4</priority>
-                            <description/>
-                            <type>0</type>
-                            <manual_close>0</manual_close>
-                            <dependencies/>
-                            <tags/>
-                        </trigger_prototype>
-                    </trigger_prototypes>
-                    <graph_prototypes/>
-                    <host_prototypes/>
-                    <jmx_endpoint/>
-                    <timeout>3s</timeout>
-                    <url/>
-                    <query_fields/>
-                    <posts/>
-                    <status_codes>200</status_codes>
-                    <follow_redirects>1</follow_redirects>
-                    <post_type>0</post_type>
-                    <http_proxy/>
-                    <headers/>
-                    <retrieve_mode>0</retrieve_mode>
-                    <request_method>1</request_method>
-                    <allow_traps>0</allow_traps>
-                    <ssl_cert_file/>
-                    <ssl_key_file/>
-                    <ssl_key_password/>
-                    <verify_peer>0</verify_peer>
-                    <verify_host>0</verify_host>
-                </discovery_rule>
-                <discovery_rule>
-                    <name>PortEth</name>
-                    <type>2</type>
-                    <snmp_community/>
-                    <snmp_oid/>
-                    <key>ethernetPort</key>
-                    <delay>0</delay>
-                    <status>0</status>
-                    <allowed_hosts/>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <filter>
-                        <evaltype>0</evaltype>
-                        <formula/>
-                        <conditions/>
-                    </filter>
-                    <lifetime>1d</lifetime>
-                    <description/>
-                    <item_prototypes>
-                        <item_prototype>
-                            <name>Health status of Ethernet port &quot;{#ID}&quot;</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>health.ethernetPort.[{#ID}]</key>
-                            <delay>0</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>Eth health</name>
-                                </application>
-                            </applications>
-                            <valuemap>
-                                <name>Unity_Health_Status</name>
-                            </valuemap>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <timeout>3s</timeout>
-                            <url/>
-                            <query_fields/>
-                            <posts/>
-                            <status_codes>200</status_codes>
-                            <follow_redirects>1</follow_redirects>
-                            <post_type>0</post_type>
-                            <http_proxy/>
-                            <headers/>
-                            <retrieve_mode>0</retrieve_mode>
-                            <request_method>1</request_method>
-                            <output_format>0</output_format>
-                            <allow_traps>0</allow_traps>
-                            <ssl_cert_file/>
-                            <ssl_key_file/>
-                            <ssl_key_password/>
-                            <verify_peer>0</verify_peer>
-                            <verify_host>0</verify_host>
-                            <application_prototypes/>
-                            <master_item/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>Running status of Ethernet port &quot;{#ID}&quot;</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>link.ethernetPort.[{#ID}]</key>
-                            <delay>0</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>Eth</name>
-                                </application>
-                            </applications>
-                            <valuemap>
-                                <name>Unity_Running_Status</name>
-                            </valuemap>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <timeout>3s</timeout>
-                            <url/>
-                            <query_fields/>
-                            <posts/>
-                            <status_codes>200</status_codes>
-                            <follow_redirects>1</follow_redirects>
-                            <post_type>0</post_type>
-                            <http_proxy/>
-                            <headers/>
-                            <retrieve_mode>0</retrieve_mode>
-                            <request_method>1</request_method>
-                            <output_format>0</output_format>
-                            <allow_traps>0</allow_traps>
-                            <ssl_cert_file/>
-                            <ssl_key_file/>
-                            <ssl_key_password/>
-                            <verify_peer>0</verify_peer>
-                            <verify_host>0</verify_host>
-                            <application_prototypes/>
-                            <master_item/>
-                        </item_prototype>
-                    </item_prototypes>
-                    <trigger_prototypes>
-                        <trigger_prototype>
-                            <expression>{Template EMC Unity REST-API v3:health.ethernetPort.[{#ID}].last()}&lt;&gt;5</expression>
-                            <recovery_mode>0</recovery_mode>
-                            <recovery_expression/>
-                            <name>{HOST.NAME} -&gt; Ethernet Port &quot;{#ID}&quot; health status is {ITEM.VALUE}</name>
-                            <correlation_mode>0</correlation_mode>
-                            <correlation_tag/>
-                            <url/>
-                            <status>0</status>
-                            <priority>4</priority>
-                            <description/>
-                            <type>0</type>
-                            <manual_close>0</manual_close>
-                            <dependencies/>
-                            <tags/>
-                        </trigger_prototype>
-                        <trigger_prototype>
-                            <expression>({TRIGGER.VALUE}=0 and {Template EMC Unity REST-API v3:link.ethernetPort.[{#ID}].last()}=11 and {Template EMC Unity REST-API v3:link.ethernetPort.[{#ID}].change()}=1) or ({TRIGGER.VALUE}=1 and {Template EMC Unity REST-API v3:link.ethernetPort.[{#ID}].change()}=0)</expression>
-                            <recovery_mode>0</recovery_mode>
-                            <recovery_expression/>
-                            <name>{HOST.NAME} -&gt; Ethernet Port &quot;{#ID}&quot; running status is {ITEM.VALUE}</name>
-                            <correlation_mode>0</correlation_mode>
-                            <correlation_tag/>
-                            <url/>
-                            <status>0</status>
-                            <priority>4</priority>
-                            <description>Триггер настроен так, что те порты, которые имеют линк-даун (еще не введены в эксплуатацию) - по ним триггеров нет.&#13;
-Те порты, которые линк-ап (эксплуатириуются) - при смене состояния триггер загорается</description>
-                            <type>0</type>
-                            <manual_close>0</manual_close>
-                            <dependencies/>
-                            <tags/>
-                        </trigger_prototype>
-                    </trigger_prototypes>
-                    <graph_prototypes/>
-                    <host_prototypes/>
-                    <jmx_endpoint/>
-                    <timeout>3s</timeout>
-                    <url/>
-                    <query_fields/>
-                    <posts/>
-                    <status_codes>200</status_codes>
-                    <follow_redirects>1</follow_redirects>
-                    <post_type>0</post_type>
-                    <http_proxy/>
-                    <headers/>
-                    <retrieve_mode>0</retrieve_mode>
-                    <request_method>1</request_method>
-                    <allow_traps>0</allow_traps>
-                    <ssl_cert_file/>
-                    <ssl_key_file/>
-                    <ssl_key_password/>
-                    <verify_peer>0</verify_peer>
-                    <verify_host>0</verify_host>
-                </discovery_rule>
-                <discovery_rule>
-                    <name>FAN</name>
-                    <type>2</type>
-                    <snmp_community/>
-                    <snmp_oid/>
-                    <key>fan</key>
-                    <delay>0</delay>
-                    <status>0</status>
-                    <allowed_hosts/>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <filter>
-                        <evaltype>0</evaltype>
-                        <formula/>
-                        <conditions/>
-                    </filter>
-                    <lifetime>1d</lifetime>
-                    <description/>
-                    <item_prototypes>
-                        <item_prototype>
-                            <name>Health Status of FAN &quot;{#ID}&quot;</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>health.fan.[{#ID}]</key>
-                            <delay>0</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>FAN health</name>
-                                </application>
-                            </applications>
-                            <valuemap>
-                                <name>Unity_Health_Status</name>
-                            </valuemap>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <timeout>3s</timeout>
-                            <url/>
-                            <query_fields/>
-                            <posts/>
-                            <status_codes>200</status_codes>
-                            <follow_redirects>1</follow_redirects>
-                            <post_type>0</post_type>
-                            <http_proxy/>
-                            <headers/>
-                            <retrieve_mode>0</retrieve_mode>
-                            <request_method>1</request_method>
-                            <output_format>0</output_format>
-                            <allow_traps>0</allow_traps>
-                            <ssl_cert_file/>
-                            <ssl_key_file/>
-                            <ssl_key_password/>
-                            <verify_peer>0</verify_peer>
-                            <verify_host>0</verify_host>
-                            <application_prototypes/>
-                            <master_item/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>Running Status of FAN &quot;{#ID}&quot;</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>running.fan.[{#ID}]</key>
-                            <delay>0</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>FAN</name>
-                                </application>
-                            </applications>
-                            <valuemap>
-                                <name>Unity_Running_Status</name>
-                            </valuemap>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <timeout>3s</timeout>
-                            <url/>
-                            <query_fields/>
-                            <posts/>
-                            <status_codes>200</status_codes>
-                            <follow_redirects>1</follow_redirects>
-                            <post_type>0</post_type>
-                            <http_proxy/>
-                            <headers/>
-                            <retrieve_mode>0</retrieve_mode>
-                            <request_method>1</request_method>
-                            <output_format>0</output_format>
-                            <allow_traps>0</allow_traps>
-                            <ssl_cert_file/>
-                            <ssl_key_file/>
-                            <ssl_key_password/>
-                            <verify_peer>0</verify_peer>
-                            <verify_host>0</verify_host>
-                            <application_prototypes/>
-                            <master_item/>
-                        </item_prototype>
-                    </item_prototypes>
-                    <trigger_prototypes>
-                        <trigger_prototype>
-                            <expression>{Template EMC Unity REST-API v3:health.fan.[{#ID}].last()}&lt;&gt;5</expression>
-                            <recovery_mode>0</recovery_mode>
-                            <recovery_expression/>
-                            <name>{HOST.NAME} -&gt; FAN &quot;{#ID}&quot; health status is {ITEM.VALUE}</name>
-                            <correlation_mode>0</correlation_mode>
-                            <correlation_tag/>
-                            <url/>
-                            <status>0</status>
-                            <priority>4</priority>
-                            <description/>
-                            <type>0</type>
-                            <manual_close>0</manual_close>
-                            <dependencies/>
-                            <tags/>
-                        </trigger_prototype>
-                        <trigger_prototype>
-                            <expression>{Template EMC Unity REST-API v3:running.fan.[{#ID}].last()}&lt;&gt;8</expression>
-                            <recovery_mode>0</recovery_mode>
-                            <recovery_expression/>
-                            <name>{HOST.NAME} -&gt; FAN &quot;{#ID}&quot; running status is {ITEM.VALUE}</name>
-                            <correlation_mode>0</correlation_mode>
-                            <correlation_tag/>
-                            <url/>
-                            <status>0</status>
-                            <priority>4</priority>
-                            <description/>
-                            <type>0</type>
-                            <manual_close>0</manual_close>
-                            <dependencies/>
-                            <tags/>
-                        </trigger_prototype>
-                    </trigger_prototypes>
-                    <graph_prototypes/>
-                    <host_prototypes/>
-                    <jmx_endpoint/>
-                    <timeout>3s</timeout>
-                    <url/>
-                    <query_fields/>
-                    <posts/>
-                    <status_codes>200</status_codes>
-                    <follow_redirects>1</follow_redirects>
-                    <post_type>0</post_type>
-                    <http_proxy/>
-                    <headers/>
-                    <retrieve_mode>0</retrieve_mode>
-                    <request_method>1</request_method>
-                    <allow_traps>0</allow_traps>
-                    <ssl_cert_file/>
-                    <ssl_key_file/>
-                    <ssl_key_password/>
-                    <verify_peer>0</verify_peer>
-                    <verify_host>0</verify_host>
-                </discovery_rule>
-                <discovery_rule>
-                    <name>PortFibreChannel</name>
-                    <type>2</type>
-                    <snmp_community/>
-                    <snmp_oid/>
-                    <key>fcPort</key>
-                    <delay>0</delay>
-                    <status>0</status>
-                    <allowed_hosts/>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <filter>
-                        <evaltype>0</evaltype>
-                        <formula/>
-                        <conditions/>
-                    </filter>
-                    <lifetime>1d</lifetime>
-                    <description/>
-                    <item_prototypes>
-                        <item_prototype>
-                            <name>Health status of Fibre Channel port &quot;{#ID}&quot;</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>health.fcPort.[{#ID}]</key>
-                            <delay>0</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>FC health</name>
-                                </application>
-                            </applications>
-                            <valuemap>
-                                <name>Unity_Health_Status</name>
-                            </valuemap>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <timeout>3s</timeout>
-                            <url/>
-                            <query_fields/>
-                            <posts/>
-                            <status_codes>200</status_codes>
-                            <follow_redirects>1</follow_redirects>
-                            <post_type>0</post_type>
-                            <http_proxy/>
-                            <headers/>
-                            <retrieve_mode>0</retrieve_mode>
-                            <request_method>1</request_method>
-                            <output_format>0</output_format>
-                            <allow_traps>0</allow_traps>
-                            <ssl_cert_file/>
-                            <ssl_key_file/>
-                            <ssl_key_password/>
-                            <verify_peer>0</verify_peer>
-                            <verify_host>0</verify_host>
-                            <application_prototypes/>
-                            <master_item/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>Running status of Fibre Channel port &quot;{#ID}&quot;</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>link.fcPort.[{#ID}]</key>
-                            <delay>0</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>FC Port</name>
-                                </application>
-                            </applications>
-                            <valuemap>
-                                <name>Unity_Running_Status</name>
-                            </valuemap>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <timeout>3s</timeout>
-                            <url/>
-                            <query_fields/>
-                            <posts/>
-                            <status_codes>200</status_codes>
-                            <follow_redirects>1</follow_redirects>
-                            <post_type>0</post_type>
-                            <http_proxy/>
-                            <headers/>
-                            <retrieve_mode>0</retrieve_mode>
-                            <request_method>1</request_method>
-                            <output_format>0</output_format>
-                            <allow_traps>0</allow_traps>
-                            <ssl_cert_file/>
-                            <ssl_key_file/>
-                            <ssl_key_password/>
-                            <verify_peer>0</verify_peer>
-                            <verify_host>0</verify_host>
-                            <application_prototypes/>
-                            <master_item/>
-                        </item_prototype>
-                    </item_prototypes>
-                    <trigger_prototypes>
-                        <trigger_prototype>
-                            <expression>{Template EMC Unity REST-API v3:health.fcPort.[{#ID}].last()}&lt;&gt;5</expression>
-                            <recovery_mode>0</recovery_mode>
-                            <recovery_expression/>
-                            <name>{HOST.NAME} -&gt; FibreChannel Port &quot;{#ID}&quot; health status is {ITEM.VALUE}</name>
-                            <correlation_mode>0</correlation_mode>
-                            <correlation_tag/>
-                            <url/>
-                            <status>0</status>
-                            <priority>4</priority>
-                            <description/>
-                            <type>0</type>
-                            <manual_close>0</manual_close>
-                            <dependencies/>
-                            <tags/>
-                        </trigger_prototype>
-                        <trigger_prototype>
-                            <expression>({TRIGGER.VALUE}=0 and {Template EMC Unity REST-API v3:link.fcPort.[{#ID}].last()}=11 and {Template EMC Unity REST-API v3:link.fcPort.[{#ID}].change()}=1) or ({TRIGGER.VALUE}=1) and {Template EMC Unity REST-API v3:link.fcPort.[{#ID}].change()}=0</expression>
-                            <recovery_mode>0</recovery_mode>
-                            <recovery_expression/>
-                            <name>{HOST.NAME} -&gt; FibreChannel Port &quot;{#ID}&quot; running status is {ITEM.VALUE}</name>
-                            <correlation_mode>0</correlation_mode>
-                            <correlation_tag/>
-                            <url/>
-                            <status>0</status>
-                            <priority>4</priority>
-                            <description>Триггер настроен так, что те порты, которые имеют линк-даун (еще не введены в эксплуатацию) - по ним триггеров нет.&#13;
-Те порты, которые линк-ап (эксплуатириуются) - при смене состояния триггер загорается</description>
-                            <type>0</type>
-                            <manual_close>0</manual_close>
-                            <dependencies/>
-                            <tags/>
-                        </trigger_prototype>
-                    </trigger_prototypes>
-                    <graph_prototypes/>
-                    <host_prototypes/>
-                    <jmx_endpoint/>
-                    <timeout>3s</timeout>
-                    <url/>
-                    <query_fields/>
-                    <posts/>
-                    <status_codes>200</status_codes>
-                    <follow_redirects>1</follow_redirects>
-                    <post_type>0</post_type>
-                    <http_proxy/>
-                    <headers/>
-                    <retrieve_mode>0</retrieve_mode>
-                    <request_method>1</request_method>
-                    <allow_traps>0</allow_traps>
-                    <ssl_cert_file/>
-                    <ssl_key_file/>
-                    <ssl_key_password/>
-                    <verify_peer>0</verify_peer>
-                    <verify_host>0</verify_host>
-                </discovery_rule>
-                <discovery_rule>
-                    <name>I/O Module</name>
-                    <type>2</type>
-                    <snmp_community/>
-                    <snmp_oid/>
-                    <key>ioModule</key>
-                    <delay>0</delay>
-                    <status>0</status>
-                    <allowed_hosts/>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <filter>
-                        <evaltype>0</evaltype>
-                        <formula/>
-                        <conditions/>
-                    </filter>
-                    <lifetime>1d</lifetime>
-                    <description>I/O modules provide connectivity between SPs and Disk-Array Enclosures (DAEs)</description>
-                    <item_prototypes>
-                        <item_prototype>
-                            <name>Health status of ioModule &quot;{#ID}&quot;</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>health.ioModule.[{#ID}]</key>
-                            <delay>0</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>I/O Module health</name>
-                                </application>
-                            </applications>
-                            <valuemap>
-                                <name>Unity_Health_Status</name>
-                            </valuemap>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <timeout>3s</timeout>
-                            <url/>
-                            <query_fields/>
-                            <posts/>
-                            <status_codes>200</status_codes>
-                            <follow_redirects>1</follow_redirects>
-                            <post_type>0</post_type>
-                            <http_proxy/>
-                            <headers/>
-                            <retrieve_mode>0</retrieve_mode>
-                            <request_method>1</request_method>
-                            <output_format>0</output_format>
-                            <allow_traps>0</allow_traps>
-                            <ssl_cert_file/>
-                            <ssl_key_file/>
-                            <ssl_key_password/>
-                            <verify_peer>0</verify_peer>
-                            <verify_host>0</verify_host>
-                            <application_prototypes/>
-                            <master_item/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>Running status of ioModule &quot;{#ID}&quot;</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>running.ioModule.[{#ID}]</key>
-                            <delay>0</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>I/O Module health</name>
-                                </application>
-                            </applications>
-                            <valuemap>
-                                <name>Unity_Running_Status</name>
-                            </valuemap>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <timeout>3s</timeout>
-                            <url/>
-                            <query_fields/>
-                            <posts/>
-                            <status_codes>200</status_codes>
-                            <follow_redirects>1</follow_redirects>
-                            <post_type>0</post_type>
-                            <http_proxy/>
-                            <headers/>
-                            <retrieve_mode>0</retrieve_mode>
-                            <request_method>1</request_method>
-                            <output_format>0</output_format>
-                            <allow_traps>0</allow_traps>
-                            <ssl_cert_file/>
-                            <ssl_key_file/>
-                            <ssl_key_password/>
-                            <verify_peer>0</verify_peer>
-                            <verify_host>0</verify_host>
-                            <application_prototypes/>
-                            <master_item/>
-                        </item_prototype>
-                    </item_prototypes>
-                    <trigger_prototypes>
-                        <trigger_prototype>
-                            <expression>{Template EMC Unity REST-API v3:health.ioModule.[{#ID}].last()}&lt;&gt;5</expression>
-                            <recovery_mode>0</recovery_mode>
-                            <recovery_expression/>
-                            <name>{HOST.NAME} -&gt; ioModule &quot;{#ID}&quot; health status is {ITEM.VALUE}</name>
-                            <correlation_mode>0</correlation_mode>
-                            <correlation_tag/>
-                            <url/>
-                            <status>0</status>
-                            <priority>4</priority>
-                            <description/>
-                            <type>0</type>
-                            <manual_close>0</manual_close>
-                            <dependencies/>
-                            <tags/>
-                        </trigger_prototype>
-                        <trigger_prototype>
-                            <expression>{Template EMC Unity REST-API v3:running.ioModule.[{#ID}].last()}&lt;&gt;8</expression>
-                            <recovery_mode>0</recovery_mode>
-                            <recovery_expression/>
-                            <name>{HOST.NAME} -&gt; ioModule &quot;{#ID}&quot; running status is {ITEM.VALUE}</name>
-                            <correlation_mode>0</correlation_mode>
-                            <correlation_tag/>
-                            <url/>
-                            <status>0</status>
-                            <priority>4</priority>
-                            <description/>
-                            <type>0</type>
-                            <manual_close>0</manual_close>
-                            <dependencies/>
-                            <tags/>
-                        </trigger_prototype>
-                    </trigger_prototypes>
-                    <graph_prototypes/>
-                    <host_prototypes/>
-                    <jmx_endpoint/>
-                    <timeout>3s</timeout>
-                    <url/>
-                    <query_fields/>
-                    <posts/>
-                    <status_codes>200</status_codes>
-                    <follow_redirects>1</follow_redirects>
-                    <post_type>0</post_type>
-                    <http_proxy/>
-                    <headers/>
-                    <retrieve_mode>0</retrieve_mode>
-                    <request_method>1</request_method>
-                    <allow_traps>0</allow_traps>
-                    <ssl_cert_file/>
-                    <ssl_key_file/>
-                    <ssl_key_password/>
-                    <verify_peer>0</verify_peer>
-                    <verify_host>0</verify_host>
-                </discovery_rule>
-                <discovery_rule>
-                    <name>LCC</name>
-                    <type>2</type>
-                    <snmp_community/>
-                    <snmp_oid/>
-                    <key>lcc</key>
-                    <delay>0</delay>
-                    <status>0</status>
-                    <allowed_hosts/>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <filter>
-                        <evaltype>0</evaltype>
-                        <formula/>
-                        <conditions/>
-                    </filter>
-                    <lifetime>1d</lifetime>
-                    <description>Link Control Cards (LCCs)</description>
-                    <item_prototypes>
-                        <item_prototype>
-                            <name>Health status of LLC &quot;{#ID}&quot;</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>health.lcc.[{#ID}]</key>
-                            <delay>0</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>LCC health</name>
-                                </application>
-                            </applications>
-                            <valuemap>
-                                <name>Unity_Health_Status</name>
-                            </valuemap>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <timeout>3s</timeout>
-                            <url/>
-                            <query_fields/>
-                            <posts/>
-                            <status_codes>200</status_codes>
-                            <follow_redirects>1</follow_redirects>
-                            <post_type>0</post_type>
-                            <http_proxy/>
-                            <headers/>
-                            <retrieve_mode>0</retrieve_mode>
-                            <request_method>1</request_method>
-                            <output_format>0</output_format>
-                            <allow_traps>0</allow_traps>
-                            <ssl_cert_file/>
-                            <ssl_key_file/>
-                            <ssl_key_password/>
-                            <verify_peer>0</verify_peer>
-                            <verify_host>0</verify_host>
-                            <application_prototypes/>
-                            <master_item/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>Running status of LLC &quot;{#ID}&quot;</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>running.lcc.[{#ID}]</key>
-                            <delay>0</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>LCC health</name>
-                                </application>
-                            </applications>
-                            <valuemap>
-                                <name>Unity_Running_Status</name>
-                            </valuemap>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <timeout>3s</timeout>
-                            <url/>
-                            <query_fields/>
-                            <posts/>
-                            <status_codes>200</status_codes>
-                            <follow_redirects>1</follow_redirects>
-                            <post_type>0</post_type>
-                            <http_proxy/>
-                            <headers/>
-                            <retrieve_mode>0</retrieve_mode>
-                            <request_method>1</request_method>
-                            <output_format>0</output_format>
-                            <allow_traps>0</allow_traps>
-                            <ssl_cert_file/>
-                            <ssl_key_file/>
-                            <ssl_key_password/>
-                            <verify_peer>0</verify_peer>
-                            <verify_host>0</verify_host>
-                            <application_prototypes/>
-                            <master_item/>
-                        </item_prototype>
-                    </item_prototypes>
-                    <trigger_prototypes>
-                        <trigger_prototype>
-                            <expression>{Template EMC Unity REST-API v3:health.lcc.[{#ID}].last()}&lt;&gt;5</expression>
-                            <recovery_mode>0</recovery_mode>
-                            <recovery_expression/>
-                            <name>{HOST.NAME} -&gt; LCC &quot;{#ID}&quot; health status is {ITEM.VALUE}</name>
-                            <correlation_mode>0</correlation_mode>
-                            <correlation_tag/>
-                            <url/>
-                            <status>0</status>
-                            <priority>4</priority>
-                            <description/>
-                            <type>0</type>
-                            <manual_close>0</manual_close>
-                            <dependencies/>
-                            <tags/>
-                        </trigger_prototype>
-                        <trigger_prototype>
-                            <expression>{Template EMC Unity REST-API v3:running.lcc.[{#ID}].last()}&lt;&gt;8</expression>
-                            <recovery_mode>0</recovery_mode>
-                            <recovery_expression/>
-                            <name>{HOST.NAME} -&gt; LCC &quot;{#ID}&quot; running status is {ITEM.VALUE}</name>
-                            <correlation_mode>0</correlation_mode>
-                            <correlation_tag/>
-                            <url/>
-                            <status>0</status>
-                            <priority>4</priority>
-                            <description/>
-                            <type>0</type>
-                            <manual_close>0</manual_close>
-                            <dependencies/>
-                            <tags/>
-                        </trigger_prototype>
-                    </trigger_prototypes>
-                    <graph_prototypes/>
-                    <host_prototypes/>
-                    <jmx_endpoint/>
-                    <timeout>3s</timeout>
-                    <url/>
-                    <query_fields/>
-                    <posts/>
-                    <status_codes>200</status_codes>
-                    <follow_redirects>1</follow_redirects>
-                    <post_type>0</post_type>
-                    <http_proxy/>
-                    <headers/>
-                    <retrieve_mode>0</retrieve_mode>
-                    <request_method>1</request_method>
-                    <allow_traps>0</allow_traps>
-                    <ssl_cert_file/>
-                    <ssl_key_file/>
-                    <ssl_key_password/>
-                    <verify_peer>0</verify_peer>
-                    <verify_host>0</verify_host>
-                </discovery_rule>
-                <discovery_rule>
-                    <name>Lun</name>
-                    <type>2</type>
-                    <snmp_community/>
-                    <snmp_oid/>
-                    <key>lun</key>
-                    <delay>0</delay>
-                    <status>0</status>
-                    <allowed_hosts/>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <filter>
-                        <evaltype>0</evaltype>
-                        <formula/>
-                        <conditions/>
-                    </filter>
-                    <lifetime>1d</lifetime>
-                    <description/>
-                    <item_prototypes>
-                        <item_prototype>
-                            <name>Health status of Lun &quot;{#NAME}&quot;</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>health.lun.[{#NAME}]</key>
-                            <delay>0</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>LUN health</name>
-                                </application>
-                            </applications>
-                            <valuemap>
-                                <name>Unity_Health_Status</name>
-                            </valuemap>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <timeout>3s</timeout>
-                            <url/>
-                            <query_fields/>
-                            <posts/>
-                            <status_codes>200</status_codes>
-                            <follow_redirects>1</follow_redirects>
-                            <post_type>0</post_type>
-                            <http_proxy/>
-                            <headers/>
-                            <retrieve_mode>0</retrieve_mode>
-                            <request_method>1</request_method>
-                            <output_format>0</output_format>
-                            <allow_traps>0</allow_traps>
-                            <ssl_cert_file/>
-                            <ssl_key_file/>
-                            <ssl_key_password/>
-                            <verify_peer>0</verify_peer>
-                            <verify_host>0</verify_host>
-                            <application_prototypes/>
-                            <master_item/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>Allocated size of Lun &quot;{#NAME}&quot;</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>sizeAllocated.lun.[{#NAME}]</key>
-                            <delay>0</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units>B</units>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description>Size of space actually allocated in the pool for the LUN:&#13;
-         For thin-provisioned LUNs this as a rule is less than the sizeTotal attribute until the LUN is not fully populated with user data.&#13;
-         For not thin-provisioned LUNs this is approximately equal to the sizeTotal.</description>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>LUN</name>
-                                </application>
-                            </applications>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <timeout>3s</timeout>
-                            <url/>
-                            <query_fields/>
-                            <posts/>
-                            <status_codes>200</status_codes>
-                            <follow_redirects>1</follow_redirects>
-                            <post_type>0</post_type>
-                            <http_proxy/>
-                            <headers/>
-                            <retrieve_mode>0</retrieve_mode>
-                            <request_method>0</request_method>
-                            <output_format>0</output_format>
-                            <allow_traps>0</allow_traps>
-                            <ssl_cert_file/>
-                            <ssl_key_file/>
-                            <ssl_key_password/>
-                            <verify_peer>0</verify_peer>
-                            <verify_host>0</verify_host>
-                            <application_prototypes/>
-                            <master_item/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>Total size of Lun &quot;{#NAME}&quot;</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>sizeTotal.lun.[{#NAME}]</key>
-                            <delay>0</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units>B</units>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description>LUN size that the system presents to the host or end user.</description>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>LUN</name>
-                                </application>
-                            </applications>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <timeout>3s</timeout>
-                            <url/>
-                            <query_fields/>
-                            <posts/>
-                            <status_codes>200</status_codes>
-                            <follow_redirects>1</follow_redirects>
-                            <post_type>0</post_type>
-                            <http_proxy/>
-                            <headers/>
-                            <retrieve_mode>0</retrieve_mode>
-                            <request_method>0</request_method>
-                            <output_format>0</output_format>
-                            <allow_traps>0</allow_traps>
-                            <ssl_cert_file/>
-                            <ssl_key_file/>
-                            <ssl_key_password/>
-                            <verify_peer>0</verify_peer>
-                            <verify_host>0</verify_host>
-                            <application_prototypes/>
-                            <master_item/>
-                        </item_prototype>
-                    </item_prototypes>
-                    <trigger_prototypes>
-                        <trigger_prototype>
-                            <expression>{Template EMC Unity REST-API v3:health.lun.[{#NAME}].last()}&lt;&gt;5</expression>
-                            <recovery_mode>0</recovery_mode>
-                            <recovery_expression/>
-                            <name>{HOST.NAME} -&gt; Lun &quot;{#NAME}&quot; health status is {ITEM.VALUE}</name>
-                            <correlation_mode>0</correlation_mode>
-                            <correlation_tag/>
-                            <url/>
-                            <status>0</status>
-                            <priority>4</priority>
-                            <description/>
-                            <type>0</type>
-                            <manual_close>0</manual_close>
-                            <dependencies/>
-                            <tags/>
-                        </trigger_prototype>
-                    </trigger_prototypes>
-                    <graph_prototypes/>
-                    <host_prototypes/>
-                    <jmx_endpoint/>
-                    <timeout>3s</timeout>
-                    <url/>
-                    <query_fields/>
-                    <posts/>
-                    <status_codes>200</status_codes>
-                    <follow_redirects>1</follow_redirects>
-                    <post_type>0</post_type>
-                    <http_proxy/>
-                    <headers/>
-                    <retrieve_mode>0</retrieve_mode>
-                    <request_method>1</request_method>
-                    <allow_traps>0</allow_traps>
-                    <ssl_cert_file/>
-                    <ssl_key_file/>
-                    <ssl_key_password/>
-                    <verify_peer>0</verify_peer>
-                    <verify_host>0</verify_host>
-                </discovery_rule>
-                <discovery_rule>
-                    <name>Memory Module</name>
-                    <type>2</type>
-                    <snmp_community/>
-                    <snmp_oid/>
-                    <key>memoryModule</key>
-                    <delay>0</delay>
-                    <status>0</status>
-                    <allowed_hosts/>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <filter>
-                        <evaltype>0</evaltype>
-                        <formula/>
-                        <conditions/>
-                    </filter>
-                    <lifetime>1d</lifetime>
-                    <description/>
-                    <item_prototypes>
-                        <item_prototype>
-                            <name>Health status of Memory Module &quot;{#ID}&quot;</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>health.memoryModule.[{#ID}]</key>
-                            <delay>0</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>MemoryModule health</name>
-                                </application>
-                            </applications>
-                            <valuemap>
-                                <name>Unity_Health_Status</name>
-                            </valuemap>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <timeout>3s</timeout>
-                            <url/>
-                            <query_fields/>
-                            <posts/>
-                            <status_codes>200</status_codes>
-                            <follow_redirects>1</follow_redirects>
-                            <post_type>0</post_type>
-                            <http_proxy/>
-                            <headers/>
-                            <retrieve_mode>0</retrieve_mode>
-                            <request_method>1</request_method>
-                            <output_format>0</output_format>
-                            <allow_traps>0</allow_traps>
-                            <ssl_cert_file/>
-                            <ssl_key_file/>
-                            <ssl_key_password/>
-                            <verify_peer>0</verify_peer>
-                            <verify_host>0</verify_host>
-                            <application_prototypes/>
-                            <master_item/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>Running status of Memory Module &quot;{#ID}&quot;</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>running.memoryModule.[{#ID}]</key>
-                            <delay>0</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>Eth</name>
-                                </application>
-                                <application>
-                                    <name>MemoryModule</name>
-                                </application>
-                            </applications>
-                            <valuemap>
-                                <name>Unity_Running_Status</name>
-                            </valuemap>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <timeout>3s</timeout>
-                            <url/>
-                            <query_fields/>
-                            <posts/>
-                            <status_codes>200</status_codes>
-                            <follow_redirects>1</follow_redirects>
-                            <post_type>0</post_type>
-                            <http_proxy/>
-                            <headers/>
-                            <retrieve_mode>0</retrieve_mode>
-                            <request_method>1</request_method>
-                            <output_format>0</output_format>
-                            <allow_traps>0</allow_traps>
-                            <ssl_cert_file/>
-                            <ssl_key_file/>
-                            <ssl_key_password/>
-                            <verify_peer>0</verify_peer>
-                            <verify_host>0</verify_host>
-                            <application_prototypes/>
-                            <master_item/>
-                        </item_prototype>
-                    </item_prototypes>
-                    <trigger_prototypes>
-                        <trigger_prototype>
-                            <expression>{Template EMC Unity REST-API v3:health.memoryModule.[{#ID}].last()}&lt;&gt;5</expression>
-                            <recovery_mode>0</recovery_mode>
-                            <recovery_expression/>
-                            <name>{HOST.NAME} -&gt; MemoryModule &quot;{#ID}&quot; health status is {ITEM.VALUE}</name>
-                            <correlation_mode>0</correlation_mode>
-                            <correlation_tag/>
-                            <url/>
-                            <status>0</status>
-                            <priority>4</priority>
-                            <description/>
-                            <type>0</type>
-                            <manual_close>0</manual_close>
-                            <dependencies/>
-                            <tags/>
-                        </trigger_prototype>
-                        <trigger_prototype>
-                            <expression>{Template EMC Unity REST-API v3:running.memoryModule.[{#ID}].last()}&lt;&gt;8</expression>
-                            <recovery_mode>0</recovery_mode>
-                            <recovery_expression/>
-                            <name>{HOST.NAME} -&gt; MemoryModule &quot;{#ID}&quot; running status is {ITEM.VALUE}</name>
-                            <correlation_mode>0</correlation_mode>
-                            <correlation_tag/>
-                            <url/>
-                            <status>0</status>
-                            <priority>4</priority>
-                            <description/>
-                            <type>0</type>
-                            <manual_close>0</manual_close>
-                            <dependencies/>
-                            <tags/>
-                        </trigger_prototype>
-                    </trigger_prototypes>
-                    <graph_prototypes/>
-                    <host_prototypes/>
-                    <jmx_endpoint/>
-                    <timeout>3s</timeout>
-                    <url/>
-                    <query_fields/>
-                    <posts/>
-                    <status_codes>200</status_codes>
-                    <follow_redirects>1</follow_redirects>
-                    <post_type>0</post_type>
-                    <http_proxy/>
-                    <headers/>
-                    <retrieve_mode>0</retrieve_mode>
-                    <request_method>1</request_method>
-                    <allow_traps>0</allow_traps>
-                    <ssl_cert_file/>
-                    <ssl_key_file/>
-                    <ssl_key_password/>
-                    <verify_peer>0</verify_peer>
-                    <verify_host>0</verify_host>
-                </discovery_rule>
-                <discovery_rule>
-                    <name>Pool</name>
-                    <type>2</type>
-                    <snmp_community/>
-                    <snmp_oid/>
-                    <key>pool</key>
-                    <delay>0</delay>
-                    <status>0</status>
-                    <allowed_hosts/>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <filter>
-                        <evaltype>0</evaltype>
-                        <formula/>
-                        <conditions/>
-                    </filter>
-                    <lifetime>1d</lifetime>
-                    <description/>
-                    <item_prototypes>
-                        <item_prototype>
-                            <name>Health status of Pool &quot;{#NAME}&quot;</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>health.pool.[{#NAME}]</key>
-                            <delay>0</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>Pool health</name>
-                                </application>
-                            </applications>
-                            <valuemap>
-                                <name>Unity_Health_Status</name>
-                            </valuemap>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <timeout>3s</timeout>
-                            <url/>
-                            <query_fields/>
-                            <posts/>
-                            <status_codes>200</status_codes>
-                            <follow_redirects>1</follow_redirects>
-                            <post_type>0</post_type>
-                            <http_proxy/>
-                            <headers/>
-                            <retrieve_mode>0</retrieve_mode>
-                            <request_method>1</request_method>
-                            <output_format>0</output_format>
-                            <allow_traps>0</allow_traps>
-                            <ssl_cert_file/>
-                            <ssl_key_file/>
-                            <ssl_key_password/>
-                            <verify_peer>0</verify_peer>
-                            <verify_host>0</verify_host>
-                            <application_prototypes/>
-                            <master_item/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>Subscribed size of Pool &quot;{#NAME}&quot;</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>sizeSubscribedBytes.pool.[{#NAME}]</key>
-                            <delay>0</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units>B</units>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>Pool</name>
-                                </application>
-                            </applications>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <timeout>3s</timeout>
-                            <url/>
-                            <query_fields/>
-                            <posts/>
-                            <status_codes>200</status_codes>
-                            <follow_redirects>1</follow_redirects>
-                            <post_type>0</post_type>
-                            <http_proxy/>
-                            <headers/>
-                            <retrieve_mode>0</retrieve_mode>
-                            <request_method>1</request_method>
-                            <output_format>0</output_format>
-                            <allow_traps>0</allow_traps>
-                            <ssl_cert_file/>
-                            <ssl_key_file/>
-                            <ssl_key_password/>
-                            <verify_peer>0</verify_peer>
-                            <verify_host>0</verify_host>
-                            <application_prototypes/>
-                            <master_item/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>Subscribed size of Pool &quot;{#NAME}&quot; in percent</name>
-                            <type>15</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>sizeSubscribedPercent.pool.[{#NAME}]</key>
-                            <delay>3m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>0</value_type>
-                            <allowed_hosts/>
-                            <units>%</units>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params>(100*last(&quot;sizeSubscribedBytes.pool.[{#NAME}]&quot;))/last(&quot;sizeTotalBytes.pool.[{#NAME}]&quot;)</params>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>Pool</name>
-                                </application>
-                            </applications>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <timeout>3s</timeout>
-                            <url/>
-                            <query_fields/>
-                            <posts/>
-                            <status_codes>200</status_codes>
-                            <follow_redirects>1</follow_redirects>
-                            <post_type>0</post_type>
-                            <http_proxy/>
-                            <headers/>
-                            <retrieve_mode>0</retrieve_mode>
-                            <request_method>1</request_method>
-                            <output_format>0</output_format>
-                            <allow_traps>0</allow_traps>
-                            <ssl_cert_file/>
-                            <ssl_key_file/>
-                            <ssl_key_password/>
-                            <verify_peer>0</verify_peer>
-                            <verify_host>0</verify_host>
-                            <application_prototypes/>
-                            <master_item/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>Total size of Pool &quot;{#NAME}&quot;</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>sizeTotalBytes.pool.[{#NAME}]</key>
-                            <delay>0</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units>B</units>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>Pool</name>
-                                </application>
-                            </applications>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <timeout>3s</timeout>
-                            <url/>
-                            <query_fields/>
-                            <posts/>
-                            <status_codes>200</status_codes>
-                            <follow_redirects>1</follow_redirects>
-                            <post_type>0</post_type>
-                            <http_proxy/>
-                            <headers/>
-                            <retrieve_mode>0</retrieve_mode>
-                            <request_method>1</request_method>
-                            <output_format>0</output_format>
-                            <allow_traps>0</allow_traps>
-                            <ssl_cert_file/>
-                            <ssl_key_file/>
-                            <ssl_key_password/>
-                            <verify_peer>0</verify_peer>
-                            <verify_host>0</verify_host>
-                            <application_prototypes/>
-                            <master_item/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>Used size of Pool &quot;{#NAME}&quot;</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>sizeUsedBytes.pool.[{#NAME}]</key>
-                            <delay>0</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units>B</units>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>Pool</name>
-                                </application>
-                            </applications>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <timeout>3s</timeout>
-                            <url/>
-                            <query_fields/>
-                            <posts/>
-                            <status_codes>200</status_codes>
-                            <follow_redirects>1</follow_redirects>
-                            <post_type>0</post_type>
-                            <http_proxy/>
-                            <headers/>
-                            <retrieve_mode>0</retrieve_mode>
-                            <request_method>1</request_method>
-                            <output_format>0</output_format>
-                            <allow_traps>0</allow_traps>
-                            <ssl_cert_file/>
-                            <ssl_key_file/>
-                            <ssl_key_password/>
-                            <verify_peer>0</verify_peer>
-                            <verify_host>0</verify_host>
-                            <application_prototypes/>
-                            <master_item/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>Used size of Pool &quot;{#NAME}&quot; in percent</name>
-                            <type>15</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>sizeUsedPercent.pool.[{#NAME}]</key>
-                            <delay>3m</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>0</value_type>
-                            <allowed_hosts/>
-                            <units>%</units>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params>(100*last(&quot;sizeUsedBytes.pool.[{#NAME}]&quot;))/last(&quot;sizeTotalBytes.pool.[{#NAME}]&quot;)</params>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>Pool</name>
-                                </application>
-                            </applications>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <timeout>3s</timeout>
-                            <url/>
-                            <query_fields/>
-                            <posts/>
-                            <status_codes>200</status_codes>
-                            <follow_redirects>1</follow_redirects>
-                            <post_type>0</post_type>
-                            <http_proxy/>
-                            <headers/>
-                            <retrieve_mode>0</retrieve_mode>
-                            <request_method>1</request_method>
-                            <output_format>0</output_format>
-                            <allow_traps>0</allow_traps>
-                            <ssl_cert_file/>
-                            <ssl_key_file/>
-                            <ssl_key_password/>
-                            <verify_peer>0</verify_peer>
-                            <verify_host>0</verify_host>
-                            <application_prototypes/>
-                            <master_item/>
-                        </item_prototype>
-                    </item_prototypes>
-                    <trigger_prototypes>
-                        <trigger_prototype>
-                            <expression>{Template EMC Unity REST-API v3:health.pool.[{#NAME}].last()}&lt;&gt;5</expression>
-                            <recovery_mode>0</recovery_mode>
-                            <recovery_expression/>
-                            <name>{HOST.NAME} -&gt; Pool &quot;{#NAME}&quot; health status is {ITEM.VALUE}</name>
-                            <correlation_mode>0</correlation_mode>
-                            <correlation_tag/>
-                            <url/>
-                            <status>0</status>
-                            <priority>4</priority>
-                            <description/>
-                            <type>0</type>
-                            <manual_close>0</manual_close>
-                            <dependencies/>
-                            <tags/>
-                        </trigger_prototype>
-                        <trigger_prototype>
-                            <expression>{Template EMC Unity REST-API v3:sizeSubscribedPercent.pool.[{#NAME}].last()}&gt;{$SUBSCRIBED_PERCENT:&quot;{#NAME}&quot;}</expression>
-                            <recovery_mode>0</recovery_mode>
-                            <recovery_expression/>
-                            <name>{HOST.NAME} -&gt; Subscribed capacity on pool &quot;{#NAME}&quot; &gt; {$SUBSCRIBED_PERCENT:&quot;{#NAME}&quot;}%</name>
-                            <correlation_mode>0</correlation_mode>
-                            <correlation_tag/>
-                            <url/>
-                            <status>0</status>
-                            <priority>4</priority>
-                            <description/>
-                            <type>0</type>
-                            <manual_close>0</manual_close>
-                            <dependencies/>
-                            <tags/>
-                        </trigger_prototype>
-                        <trigger_prototype>
-                            <expression>{Template EMC Unity REST-API v3:sizeUsedPercent.pool.[{#NAME}].last()}&gt;{$USED_PERCENT:&quot;{#NAME}&quot;}</expression>
-                            <recovery_mode>0</recovery_mode>
-                            <recovery_expression/>
-                            <name>{HOST.NAME} -&gt; Used capacity on pool &quot;{#NAME}&quot; &gt; {$USED_PERCENT:&quot;{#NAME}&quot;}%</name>
-                            <correlation_mode>0</correlation_mode>
-                            <correlation_tag/>
-                            <url/>
-                            <status>0</status>
-                            <priority>4</priority>
-                            <description/>
-                            <type>0</type>
-                            <manual_close>0</manual_close>
-                            <dependencies/>
-                            <tags/>
-                        </trigger_prototype>
-                    </trigger_prototypes>
-                    <graph_prototypes/>
-                    <host_prototypes/>
-                    <jmx_endpoint/>
-                    <timeout>3s</timeout>
-                    <url/>
-                    <query_fields/>
-                    <posts/>
-                    <status_codes>200</status_codes>
-                    <follow_redirects>1</follow_redirects>
-                    <post_type>0</post_type>
-                    <http_proxy/>
-                    <headers/>
-                    <retrieve_mode>0</retrieve_mode>
-                    <request_method>1</request_method>
-                    <allow_traps>0</allow_traps>
-                    <ssl_cert_file/>
-                    <ssl_key_file/>
-                    <ssl_key_password/>
-                    <verify_peer>0</verify_peer>
-                    <verify_host>0</verify_host>
-                </discovery_rule>
-                <discovery_rule>
-                    <name>PSU</name>
-                    <type>2</type>
-                    <snmp_community/>
-                    <snmp_oid/>
-                    <key>powerSupply</key>
-                    <delay>0</delay>
-                    <status>0</status>
-                    <allowed_hosts/>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <filter>
-                        <evaltype>0</evaltype>
-                        <formula/>
-                        <conditions/>
-                    </filter>
-                    <lifetime>1d</lifetime>
-                    <description/>
-                    <item_prototypes>
-                        <item_prototype>
-                            <name>Health Status of PSU &quot;{#ID}&quot;</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>health.powerSupply.[{#ID}]</key>
-                            <delay>0</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>PSU health</name>
-                                </application>
-                            </applications>
-                            <valuemap>
-                                <name>Unity_Health_Status</name>
-                            </valuemap>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <timeout>3s</timeout>
-                            <url/>
-                            <query_fields/>
-                            <posts/>
-                            <status_codes>200</status_codes>
-                            <follow_redirects>1</follow_redirects>
-                            <post_type>0</post_type>
-                            <http_proxy/>
-                            <headers/>
-                            <retrieve_mode>0</retrieve_mode>
-                            <request_method>1</request_method>
-                            <output_format>0</output_format>
-                            <allow_traps>0</allow_traps>
-                            <ssl_cert_file/>
-                            <ssl_key_file/>
-                            <ssl_key_password/>
-                            <verify_peer>0</verify_peer>
-                            <verify_host>0</verify_host>
-                            <application_prototypes/>
-                            <master_item/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>Running Status of PSU &quot;{#ID}&quot;</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>running.powerSupply.[{#ID}]</key>
-                            <delay>0</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>PSU</name>
-                                </application>
-                            </applications>
-                            <valuemap>
-                                <name>Unity_Running_Status</name>
-                            </valuemap>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <timeout>3s</timeout>
-                            <url/>
-                            <query_fields/>
-                            <posts/>
-                            <status_codes>200</status_codes>
-                            <follow_redirects>1</follow_redirects>
-                            <post_type>0</post_type>
-                            <http_proxy/>
-                            <headers/>
-                            <retrieve_mode>0</retrieve_mode>
-                            <request_method>1</request_method>
-                            <output_format>0</output_format>
-                            <allow_traps>0</allow_traps>
-                            <ssl_cert_file/>
-                            <ssl_key_file/>
-                            <ssl_key_password/>
-                            <verify_peer>0</verify_peer>
-                            <verify_host>0</verify_host>
-                            <application_prototypes/>
-                            <master_item/>
-                        </item_prototype>
-                    </item_prototypes>
-                    <trigger_prototypes>
-                        <trigger_prototype>
-                            <expression>{Template EMC Unity REST-API v3:health.powerSupply.[{#ID}].last()}&lt;&gt;5</expression>
-                            <recovery_mode>0</recovery_mode>
-                            <recovery_expression/>
-                            <name>{HOST.NAME} -&gt; PSU &quot;{#ID}&quot; health status is {ITEM.VALUE}</name>
-                            <correlation_mode>0</correlation_mode>
-                            <correlation_tag/>
-                            <url/>
-                            <status>0</status>
-                            <priority>4</priority>
-                            <description/>
-                            <type>0</type>
-                            <manual_close>0</manual_close>
-                            <dependencies/>
-                            <tags/>
-                        </trigger_prototype>
-                        <trigger_prototype>
-                            <expression>{Template EMC Unity REST-API v3:running.powerSupply.[{#ID}].last()}&lt;&gt;8</expression>
-                            <recovery_mode>0</recovery_mode>
-                            <recovery_expression/>
-                            <name>{HOST.NAME} -&gt; PSU &quot;{#ID}&quot; running status is {ITEM.VALUE}</name>
-                            <correlation_mode>0</correlation_mode>
-                            <correlation_tag/>
-                            <url/>
-                            <status>0</status>
-                            <priority>4</priority>
-                            <description/>
-                            <type>0</type>
-                            <manual_close>0</manual_close>
-                            <dependencies/>
-                            <tags/>
-                        </trigger_prototype>
-                    </trigger_prototypes>
-                    <graph_prototypes/>
-                    <host_prototypes/>
-                    <jmx_endpoint/>
-                    <timeout>3s</timeout>
-                    <url/>
-                    <query_fields/>
-                    <posts/>
-                    <status_codes>200</status_codes>
-                    <follow_redirects>1</follow_redirects>
-                    <post_type>0</post_type>
-                    <http_proxy/>
-                    <headers/>
-                    <retrieve_mode>0</retrieve_mode>
-                    <request_method>1</request_method>
-                    <allow_traps>0</allow_traps>
-                    <ssl_cert_file/>
-                    <ssl_key_file/>
-                    <ssl_key_password/>
-                    <verify_peer>0</verify_peer>
-                    <verify_host>0</verify_host>
-                </discovery_rule>
-                <discovery_rule>
-                    <name>PortSAS</name>
-                    <type>2</type>
-                    <snmp_community/>
-                    <snmp_oid/>
-                    <key>sasPort</key>
-                    <delay>0</delay>
-                    <status>0</status>
-                    <allowed_hosts/>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <filter>
-                        <evaltype>0</evaltype>
-                        <formula/>
-                        <conditions/>
-                    </filter>
-                    <lifetime>1d</lifetime>
-                    <description/>
-                    <item_prototypes>
-                        <item_prototype>
-                            <name>Health status of SAS port &quot;{#ID}&quot;</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>health.sasPort.[{#ID}]</key>
-                            <delay>0</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>SAS health</name>
-                                </application>
-                            </applications>
-                            <valuemap>
-                                <name>Unity_Health_Status</name>
-                            </valuemap>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <timeout>3s</timeout>
-                            <url/>
-                            <query_fields/>
-                            <posts/>
-                            <status_codes>200</status_codes>
-                            <follow_redirects>1</follow_redirects>
-                            <post_type>0</post_type>
-                            <http_proxy/>
-                            <headers/>
-                            <retrieve_mode>0</retrieve_mode>
-                            <request_method>1</request_method>
-                            <output_format>0</output_format>
-                            <allow_traps>0</allow_traps>
-                            <ssl_cert_file/>
-                            <ssl_key_file/>
-                            <ssl_key_password/>
-                            <verify_peer>0</verify_peer>
-                            <verify_host>0</verify_host>
-                            <application_prototypes/>
-                            <master_item/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>Running status of SAS port &quot;{#ID}&quot;</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>link.sasPort.[{#ID}]</key>
-                            <delay>0</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>SAS</name>
-                                </application>
-                            </applications>
-                            <valuemap>
-                                <name>Unity_Running_Status</name>
-                            </valuemap>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <timeout>3s</timeout>
-                            <url/>
-                            <query_fields/>
-                            <posts/>
-                            <status_codes>200</status_codes>
-                            <follow_redirects>1</follow_redirects>
-                            <post_type>0</post_type>
-                            <http_proxy/>
-                            <headers/>
-                            <retrieve_mode>0</retrieve_mode>
-                            <request_method>1</request_method>
-                            <output_format>0</output_format>
-                            <allow_traps>0</allow_traps>
-                            <ssl_cert_file/>
-                            <ssl_key_file/>
-                            <ssl_key_password/>
-                            <verify_peer>0</verify_peer>
-                            <verify_host>0</verify_host>
-                            <application_prototypes/>
-                            <master_item/>
-                        </item_prototype>
-                    </item_prototypes>
-                    <trigger_prototypes>
-                        <trigger_prototype>
-                            <expression>{Template EMC Unity REST-API v3:health.sasPort.[{#ID}].last()}&lt;&gt;5</expression>
-                            <recovery_mode>0</recovery_mode>
-                            <recovery_expression/>
-                            <name>{HOST.NAME} -&gt; SAS Port &quot;{#ID}&quot; health status is {ITEM.VALUE}</name>
-                            <correlation_mode>0</correlation_mode>
-                            <correlation_tag/>
-                            <url/>
-                            <status>0</status>
-                            <priority>4</priority>
-                            <description/>
-                            <type>0</type>
-                            <manual_close>0</manual_close>
-                            <dependencies/>
-                            <tags/>
-                        </trigger_prototype>
-                        <trigger_prototype>
-                            <expression>({TRIGGER.VALUE}=0 and {Template EMC Unity REST-API v3:link.sasPort.[{#ID}].last()}=11 and {Template EMC Unity REST-API v3:link.sasPort.[{#ID}].change()}=1) or ({TRIGGER.VALUE}=1 and {Template EMC Unity REST-API v3:link.sasPort.[{#ID}].change()}=0)</expression>
-                            <recovery_mode>0</recovery_mode>
-                            <recovery_expression/>
-                            <name>{HOST.NAME} -&gt; SAS Port &quot;{#ID}&quot; running status is {ITEM.VALUE}</name>
-                            <correlation_mode>0</correlation_mode>
-                            <correlation_tag/>
-                            <url/>
-                            <status>0</status>
-                            <priority>4</priority>
-                            <description>Триггер настроен так, что те порты, которые имеют линк-даун (еще не введены в эксплуатацию) - по ним триггеров нет.&#13;
-Те порты, которые линк-ап (эксплуатириуются) - при смене состояния триггер загорается</description>
-                            <type>0</type>
-                            <manual_close>0</manual_close>
-                            <dependencies/>
-                            <tags/>
-                        </trigger_prototype>
-                    </trigger_prototypes>
-                    <graph_prototypes/>
-                    <host_prototypes/>
-                    <jmx_endpoint/>
-                    <timeout>3s</timeout>
-                    <url/>
-                    <query_fields/>
-                    <posts/>
-                    <status_codes>200</status_codes>
-                    <follow_redirects>1</follow_redirects>
-                    <post_type>0</post_type>
-                    <http_proxy/>
-                    <headers/>
-                    <retrieve_mode>0</retrieve_mode>
-                    <request_method>1</request_method>
-                    <allow_traps>0</allow_traps>
-                    <ssl_cert_file/>
-                    <ssl_key_file/>
-                    <ssl_key_password/>
-                    <verify_peer>0</verify_peer>
-                    <verify_host>0</verify_host>
-                </discovery_rule>
-                <discovery_rule>
-                    <name>SSC</name>
-                    <type>2</type>
-                    <snmp_community/>
-                    <snmp_oid/>
-                    <key>ssc</key>
-                    <delay>0</delay>
-                    <status>0</status>
-                    <allowed_hosts/>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <filter>
-                        <evaltype>0</evaltype>
-                        <formula/>
-                        <conditions/>
-                    </filter>
-                    <lifetime>1d</lifetime>
-                    <description>System Status Cards (SSCs)</description>
-                    <item_prototypes>
-                        <item_prototype>
-                            <name>Health status of SSC &quot;{#ID}&quot;</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>health.ssc.[{#ID}]</key>
-                            <delay>0</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>SSC health</name>
-                                </application>
-                            </applications>
-                            <valuemap>
-                                <name>Unity_Health_Status</name>
-                            </valuemap>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <timeout>3s</timeout>
-                            <url/>
-                            <query_fields/>
-                            <posts/>
-                            <status_codes>200</status_codes>
-                            <follow_redirects>1</follow_redirects>
-                            <post_type>0</post_type>
-                            <http_proxy/>
-                            <headers/>
-                            <retrieve_mode>0</retrieve_mode>
-                            <request_method>1</request_method>
-                            <output_format>0</output_format>
-                            <allow_traps>0</allow_traps>
-                            <ssl_cert_file/>
-                            <ssl_key_file/>
-                            <ssl_key_password/>
-                            <verify_peer>0</verify_peer>
-                            <verify_host>0</verify_host>
-                            <application_prototypes/>
-                            <master_item/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>Running status of SSC &quot;{#ID}&quot;</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>running.ssc.[{#ID}]</key>
-                            <delay>0</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>SSC health</name>
-                                </application>
-                            </applications>
-                            <valuemap>
-                                <name>Unity_Running_Status</name>
-                            </valuemap>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <timeout>3s</timeout>
-                            <url/>
-                            <query_fields/>
-                            <posts/>
-                            <status_codes>200</status_codes>
-                            <follow_redirects>1</follow_redirects>
-                            <post_type>0</post_type>
-                            <http_proxy/>
-                            <headers/>
-                            <retrieve_mode>0</retrieve_mode>
-                            <request_method>1</request_method>
-                            <output_format>0</output_format>
-                            <allow_traps>0</allow_traps>
-                            <ssl_cert_file/>
-                            <ssl_key_file/>
-                            <ssl_key_password/>
-                            <verify_peer>0</verify_peer>
-                            <verify_host>0</verify_host>
-                            <application_prototypes/>
-                            <master_item/>
-                        </item_prototype>
-                    </item_prototypes>
-                    <trigger_prototypes>
-                        <trigger_prototype>
-                            <expression>{Template EMC Unity REST-API v3:health.ssc.[{#ID}].last()}&lt;&gt;5</expression>
-                            <recovery_mode>0</recovery_mode>
-                            <recovery_expression/>
-                            <name>{HOST.NAME} -&gt; SSC &quot;{#ID}&quot; health status is {ITEM.VALUE}</name>
-                            <correlation_mode>0</correlation_mode>
-                            <correlation_tag/>
-                            <url/>
-                            <status>0</status>
-                            <priority>4</priority>
-                            <description/>
-                            <type>0</type>
-                            <manual_close>0</manual_close>
-                            <dependencies/>
-                            <tags/>
-                        </trigger_prototype>
-                        <trigger_prototype>
-                            <expression>{Template EMC Unity REST-API v3:running.ssc.[{#ID}].last()}&lt;&gt;8</expression>
-                            <recovery_mode>0</recovery_mode>
-                            <recovery_expression/>
-                            <name>{HOST.NAME} -&gt; SSC &quot;{#ID}&quot; running status is {ITEM.VALUE}</name>
-                            <correlation_mode>0</correlation_mode>
-                            <correlation_tag/>
-                            <url/>
-                            <status>0</status>
-                            <priority>4</priority>
-                            <description/>
-                            <type>0</type>
-                            <manual_close>0</manual_close>
-                            <dependencies/>
-                            <tags/>
-                        </trigger_prototype>
-                    </trigger_prototypes>
-                    <graph_prototypes/>
-                    <host_prototypes/>
-                    <jmx_endpoint/>
-                    <timeout>3s</timeout>
-                    <url/>
-                    <query_fields/>
-                    <posts/>
-                    <status_codes>200</status_codes>
-                    <follow_redirects>1</follow_redirects>
-                    <post_type>0</post_type>
-                    <http_proxy/>
-                    <headers/>
-                    <retrieve_mode>0</retrieve_mode>
-                    <request_method>1</request_method>
-                    <allow_traps>0</allow_traps>
-                    <ssl_cert_file/>
-                    <ssl_key_file/>
-                    <ssl_key_password/>
-                    <verify_peer>0</verify_peer>
-                    <verify_host>0</verify_host>
-                </discovery_rule>
-                <discovery_rule>
-                    <name>SSD</name>
-                    <type>2</type>
-                    <snmp_community/>
-                    <snmp_oid/>
-                    <key>ssd</key>
-                    <delay>0</delay>
-                    <status>0</status>
-                    <allowed_hosts/>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <filter>
-                        <evaltype>0</evaltype>
-                        <formula/>
-                        <conditions/>
-                    </filter>
-                    <lifetime>1d</lifetime>
-                    <description/>
-                    <item_prototypes>
-                        <item_prototype>
-                            <name>Health status of SSD &quot;{#ID}&quot;</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>health.ssd.[{#ID}]</key>
-                            <delay>0</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>SSD health</name>
-                                </application>
-                            </applications>
-                            <valuemap>
-                                <name>Unity_Health_Status</name>
-                            </valuemap>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <timeout>3s</timeout>
-                            <url/>
-                            <query_fields/>
-                            <posts/>
-                            <status_codes>200</status_codes>
-                            <follow_redirects>1</follow_redirects>
-                            <post_type>0</post_type>
-                            <http_proxy/>
-                            <headers/>
-                            <retrieve_mode>0</retrieve_mode>
-                            <request_method>1</request_method>
-                            <output_format>0</output_format>
-                            <allow_traps>0</allow_traps>
-                            <ssl_cert_file/>
-                            <ssl_key_file/>
-                            <ssl_key_password/>
-                            <verify_peer>0</verify_peer>
-                            <verify_host>0</verify_host>
-                            <application_prototypes/>
-                            <master_item/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>Running status of SSD &quot;{#ID}&quot;</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>running.ssd.[{#ID}]</key>
-                            <delay>0</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>SSD health</name>
-                                </application>
-                            </applications>
-                            <valuemap>
-                                <name>Unity_Running_Status</name>
-                            </valuemap>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <timeout>3s</timeout>
-                            <url/>
-                            <query_fields/>
-                            <posts/>
-                            <status_codes>200</status_codes>
-                            <follow_redirects>1</follow_redirects>
-                            <post_type>0</post_type>
-                            <http_proxy/>
-                            <headers/>
-                            <retrieve_mode>0</retrieve_mode>
-                            <request_method>1</request_method>
-                            <output_format>0</output_format>
-                            <allow_traps>0</allow_traps>
-                            <ssl_cert_file/>
-                            <ssl_key_file/>
-                            <ssl_key_password/>
-                            <verify_peer>0</verify_peer>
-                            <verify_host>0</verify_host>
-                            <application_prototypes/>
-                            <master_item/>
-                        </item_prototype>
-                    </item_prototypes>
-                    <trigger_prototypes>
-                        <trigger_prototype>
-                            <expression>{Template EMC Unity REST-API v3:health.ssd.[{#ID}].last()}&lt;&gt;5</expression>
-                            <recovery_mode>0</recovery_mode>
-                            <recovery_expression/>
-                            <name>{HOST.NAME} -&gt; SSD &quot;{#ID}&quot; health status is {ITEM.VALUE}</name>
-                            <correlation_mode>0</correlation_mode>
-                            <correlation_tag/>
-                            <url/>
-                            <status>0</status>
-                            <priority>4</priority>
-                            <description/>
-                            <type>0</type>
-                            <manual_close>0</manual_close>
-                            <dependencies/>
-                            <tags/>
-                        </trigger_prototype>
-                        <trigger_prototype>
-                            <expression>{Template EMC Unity REST-API v3:running.ssd.[{#ID}].last()}&lt;&gt;8</expression>
-                            <recovery_mode>0</recovery_mode>
-                            <recovery_expression/>
-                            <name>{HOST.NAME} -&gt; SSD &quot;{#ID}&quot; running status is {ITEM.VALUE}</name>
-                            <correlation_mode>0</correlation_mode>
-                            <correlation_tag/>
-                            <url/>
-                            <status>0</status>
-                            <priority>4</priority>
-                            <description/>
-                            <type>0</type>
-                            <manual_close>0</manual_close>
-                            <dependencies/>
-                            <tags/>
-                        </trigger_prototype>
-                    </trigger_prototypes>
-                    <graph_prototypes/>
-                    <host_prototypes/>
-                    <jmx_endpoint/>
-                    <timeout>3s</timeout>
-                    <url/>
-                    <query_fields/>
-                    <posts/>
-                    <status_codes>200</status_codes>
-                    <follow_redirects>1</follow_redirects>
-                    <post_type>0</post_type>
-                    <http_proxy/>
-                    <headers/>
-                    <retrieve_mode>0</retrieve_mode>
-                    <request_method>1</request_method>
-                    <allow_traps>0</allow_traps>
-                    <ssl_cert_file/>
-                    <ssl_key_file/>
-                    <ssl_key_password/>
-                    <verify_peer>0</verify_peer>
-                    <verify_host>0</verify_host>
-                </discovery_rule>
-                <discovery_rule>
-                    <name>Storage Processors</name>
-                    <type>2</type>
-                    <snmp_community/>
-                    <snmp_oid/>
-                    <key>storageProcessor</key>
-                    <delay>0</delay>
-                    <status>0</status>
-                    <allowed_hosts/>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <filter>
-                        <evaltype>0</evaltype>
-                        <formula/>
-                        <conditions/>
-                    </filter>
-                    <lifetime>1d</lifetime>
-                    <description/>
-                    <item_prototypes>
-                        <item_prototype>
-                            <name>Health status of Storage Processors &quot;{#ID}&quot;</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>health.storageProcessor.[{#ID}]</key>
-                            <delay>0</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>StorageProcessor health</name>
-                                </application>
-                            </applications>
-                            <valuemap>
-                                <name>Unity_Health_Status</name>
-                            </valuemap>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <timeout>3s</timeout>
-                            <url/>
-                            <query_fields/>
-                            <posts/>
-                            <status_codes>200</status_codes>
-                            <follow_redirects>1</follow_redirects>
-                            <post_type>0</post_type>
-                            <http_proxy/>
-                            <headers/>
-                            <retrieve_mode>0</retrieve_mode>
-                            <request_method>1</request_method>
-                            <output_format>0</output_format>
-                            <allow_traps>0</allow_traps>
-                            <ssl_cert_file/>
-                            <ssl_key_file/>
-                            <ssl_key_password/>
-                            <verify_peer>0</verify_peer>
-                            <verify_host>0</verify_host>
-                            <application_prototypes/>
-                            <master_item/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>Running status of Storage Processors &quot;{#ID}&quot;</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>running.storageProcessor.[{#ID}]</key>
-                            <delay>0</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>StorageProcessor health</name>
-                                </application>
-                            </applications>
-                            <valuemap>
-                                <name>Unity_Running_Status</name>
-                            </valuemap>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <timeout>3s</timeout>
-                            <url/>
-                            <query_fields/>
-                            <posts/>
-                            <status_codes>200</status_codes>
-                            <follow_redirects>1</follow_redirects>
-                            <post_type>0</post_type>
-                            <http_proxy/>
-                            <headers/>
-                            <retrieve_mode>0</retrieve_mode>
-                            <request_method>1</request_method>
-                            <output_format>0</output_format>
-                            <allow_traps>0</allow_traps>
-                            <ssl_cert_file/>
-                            <ssl_key_file/>
-                            <ssl_key_password/>
-                            <verify_peer>0</verify_peer>
-                            <verify_host>0</verify_host>
-                            <application_prototypes/>
-                            <master_item/>
-                        </item_prototype>
-                    </item_prototypes>
-                    <trigger_prototypes>
-                        <trigger_prototype>
-                            <expression>{Template EMC Unity REST-API v3:health.storageProcessor.[{#ID}].last()}&lt;&gt;5</expression>
-                            <recovery_mode>0</recovery_mode>
-                            <recovery_expression/>
-                            <name>{HOST.NAME} -&gt; Storage Processor &quot;{#ID}&quot; health status is {ITEM.VALUE}</name>
-                            <correlation_mode>0</correlation_mode>
-                            <correlation_tag/>
-                            <url/>
-                            <status>0</status>
-                            <priority>4</priority>
-                            <description/>
-                            <type>0</type>
-                            <manual_close>0</manual_close>
-                            <dependencies/>
-                            <tags/>
-                        </trigger_prototype>
-                        <trigger_prototype>
-                            <expression>{Template EMC Unity REST-API v3:running.storageProcessor.[{#ID}].last()}&lt;&gt;8</expression>
-                            <recovery_mode>0</recovery_mode>
-                            <recovery_expression/>
-                            <name>{HOST.NAME} -&gt; Storage Processor &quot;{#ID}&quot; running status is {ITEM.VALUE}</name>
-                            <correlation_mode>0</correlation_mode>
-                            <correlation_tag/>
-                            <url/>
-                            <status>0</status>
-                            <priority>4</priority>
-                            <description/>
-                            <type>0</type>
-                            <manual_close>0</manual_close>
-                            <dependencies/>
-                            <tags/>
-                        </trigger_prototype>
-                    </trigger_prototypes>
-                    <graph_prototypes/>
-                    <host_prototypes/>
-                    <jmx_endpoint/>
-                    <timeout>3s</timeout>
-                    <url/>
-                    <query_fields/>
-                    <posts/>
-                    <status_codes>200</status_codes>
-                    <follow_redirects>1</follow_redirects>
-                    <post_type>0</post_type>
-                    <http_proxy/>
-                    <headers/>
-                    <retrieve_mode>0</retrieve_mode>
-                    <request_method>1</request_method>
-                    <allow_traps>0</allow_traps>
-                    <ssl_cert_file/>
-                    <ssl_key_file/>
-                    <ssl_key_password/>
-                    <verify_peer>0</verify_peer>
-                    <verify_host>0</verify_host>
-                </discovery_rule>
-                <discovery_rule>
-                    <name>Uncommitted Port</name>
-                    <type>2</type>
-                    <snmp_community/>
-                    <snmp_oid/>
-                    <key>uncommittedPort</key>
-                    <delay>0</delay>
-                    <status>0</status>
-                    <allowed_hosts/>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <filter>
-                        <evaltype>0</evaltype>
-                        <formula/>
-                        <conditions/>
-                    </filter>
-                    <lifetime>1d</lifetime>
-                    <description/>
-                    <item_prototypes>
-                        <item_prototype>
-                            <name>Health status of Uncommitted Port &quot;{#ID}&quot;</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>health.uncommittedPort.[{#ID}]</key>
-                            <delay>0</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>Uncommitted Port health</name>
-                                </application>
-                            </applications>
-                            <valuemap>
-                                <name>Unity_Health_Status</name>
-                            </valuemap>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <timeout>3s</timeout>
-                            <url/>
-                            <query_fields/>
-                            <posts/>
-                            <status_codes>200</status_codes>
-                            <follow_redirects>1</follow_redirects>
-                            <post_type>0</post_type>
-                            <http_proxy/>
-                            <headers/>
-                            <retrieve_mode>0</retrieve_mode>
-                            <request_method>1</request_method>
-                            <output_format>0</output_format>
-                            <allow_traps>0</allow_traps>
-                            <ssl_cert_file/>
-                            <ssl_key_file/>
-                            <ssl_key_password/>
-                            <verify_peer>0</verify_peer>
-                            <verify_host>0</verify_host>
-                            <application_prototypes/>
-                            <master_item/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>Running status of Uncommitted Port &quot;{#ID}&quot;</name>
-                            <type>2</type>
-                            <snmp_community/>
-                            <snmp_oid/>
-                            <key>running.uncommittedPort.[{#ID}]</key>
-                            <delay>0</delay>
-                            <history>90d</history>
-                            <trends>365d</trends>
-                            <status>0</status>
-                            <value_type>3</value_type>
-                            <allowed_hosts/>
-                            <units/>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications>
-                                <application>
-                                    <name>Uncommitted Port health</name>
-                                </application>
-                            </applications>
-                            <valuemap>
-                                <name>Unity_Running_Status</name>
-                            </valuemap>
-                            <logtimefmt/>
-                            <preprocessing/>
-                            <jmx_endpoint/>
-                            <timeout>3s</timeout>
-                            <url/>
-                            <query_fields/>
-                            <posts/>
-                            <status_codes>200</status_codes>
-                            <follow_redirects>1</follow_redirects>
-                            <post_type>0</post_type>
-                            <http_proxy/>
-                            <headers/>
-                            <retrieve_mode>0</retrieve_mode>
-                            <request_method>1</request_method>
-                            <output_format>0</output_format>
-                            <allow_traps>0</allow_traps>
-                            <ssl_cert_file/>
-                            <ssl_key_file/>
-                            <ssl_key_password/>
-                            <verify_peer>0</verify_peer>
-                            <verify_host>0</verify_host>
-                            <application_prototypes/>
-                            <master_item/>
-                        </item_prototype>
-                    </item_prototypes>
-                    <trigger_prototypes>
-                        <trigger_prototype>
-                            <expression>{Template EMC Unity REST-API v3:health.uncommittedPort.[{#ID}].last()}&lt;&gt;5</expression>
-                            <recovery_mode>0</recovery_mode>
-                            <recovery_expression/>
-                            <name>{HOST.NAME} -&gt; Uncommited Port &quot;{#ID}&quot; health status is {ITEM.VALUE}</name>
-                            <correlation_mode>0</correlation_mode>
-                            <correlation_tag/>
-                            <url/>
-                            <status>0</status>
-                            <priority>4</priority>
-                            <description/>
-                            <type>0</type>
-                            <manual_close>0</manual_close>
-                            <dependencies/>
-                            <tags/>
-                        </trigger_prototype>
-                        <trigger_prototype>
-                            <expression>{Template EMC Unity REST-API v3:running.uncommittedPort.[{#ID}].last()}&lt;&gt;8</expression>
-                            <recovery_mode>0</recovery_mode>
-                            <recovery_expression/>
-                            <name>{HOST.NAME} -&gt; Uncommited Port &quot;{#ID}&quot; running status is {ITEM.VALUE}</name>
-                            <correlation_mode>0</correlation_mode>
-                            <correlation_tag/>
-                            <url/>
-                            <status>0</status>
-                            <priority>4</priority>
-                            <description/>
-                            <type>0</type>
-                            <manual_close>0</manual_close>
-                            <dependencies/>
-                            <tags/>
-                        </trigger_prototype>
-                    </trigger_prototypes>
-                    <graph_prototypes/>
-                    <host_prototypes/>
-                    <jmx_endpoint/>
-                    <timeout>3s</timeout>
-                    <url/>
-                    <query_fields/>
-                    <posts/>
-                    <status_codes>200</status_codes>
-                    <follow_redirects>1</follow_redirects>
-                    <post_type>0</post_type>
-                    <http_proxy/>
-                    <headers/>
-                    <retrieve_mode>0</retrieve_mode>
-                    <request_method>1</request_method>
-                    <allow_traps>0</allow_traps>
-                    <ssl_cert_file/>
-                    <ssl_key_file/>
-                    <ssl_key_password/>
-                    <verify_peer>0</verify_peer>
-                    <verify_host>0</verify_host>
-                </discovery_rule>
-            </discovery_rules>
-            <httptests/>
-            <macros>
-                <macro>
-                    <macro>{$API_PASSWORD}</macro>
-                    <value/>
-                </macro>
-                <macro>
-                    <macro>{$API_PORT}</macro>
-                    <value>443</value>
-                </macro>
-                <macro>
-                    <macro>{$API_USER}</macro>
-                    <value/>
-                </macro>
-                <macro>
-                    <macro>{$SUBSCRIBED_PERCENT}</macro>
-                    <value>91</value>
-                </macro>
-                <macro>
-                    <macro>{$USED_PERCENT}</macro>
-                    <value>91</value>
-                </macro>
-            </macros>
-            <templates/>
-            <screens/>
-        </template>
-    </templates>
-    <triggers>
-        <trigger>
-            <expression>{Template EMC Unity REST-API v3:unity_get_state.py[&quot;--api_ip={HOST.IP}&quot;,&quot;--api_port={$API_PORT}&quot;,&quot;--api_user={$API_USER}&quot;,&quot;--api_password={$API_PASSWORD}&quot;,&quot;--storage_name={HOST.NAME}&quot;,&quot;--discovery&quot;].count(30m,2,le)}&gt;5</expression>
-            <recovery_mode>0</recovery_mode>
-            <recovery_expression/>
-            <name>{HOST.NAME} -&gt; Error occurs in getting metrics</name>
-            <correlation_mode>0</correlation_mode>
-            <correlation_tag/>
-            <url/>
-            <status>0</status>
-            <priority>4</priority>
-            <description>Ошибки zabbix-sender'a&#13;
-В течении часа приходят значеня 1 или 2 более 5 раз</description>
-            <type>0</type>
-            <manual_close>0</manual_close>
-            <dependencies/>
-            <tags>
-                <tag>
-                    <tag>Department</tag>
-                    <value>MON.RTK</value>
-                </tag>
-            </tags>
-        </trigger>
-        <trigger>
-            <expression>{Template EMC Unity REST-API v3:unity_get_state.py[&quot;--api_ip={HOST.IP}&quot;,&quot;--api_port={$API_PORT}&quot;,&quot;--api_user={$API_USER}&quot;,&quot;--api_password={$API_PASSWORD}&quot;,&quot;--storage_name={HOST.NAME}&quot;,&quot;--status&quot;].count(30m,50,ge)}&gt;5</expression>
-            <recovery_mode>0</recovery_mode>
-            <recovery_expression/>
-            <name>{HOST.NAME} -&gt; Error occurs in sending metrics</name>
-            <correlation_mode>0</correlation_mode>
-            <correlation_tag/>
-            <url/>
-            <status>0</status>
-            <priority>4</priority>
-            <description>5 раз за 30 минут приходят значения &gt;=50</description>
-            <type>0</type>
-            <manual_close>0</manual_close>
-            <dependencies/>
-            <tags>
-                <tag>
-                    <tag>Department</tag>
-                    <value>MON.RTK</value>
-                </tag>
-            </tags>
-        </trigger>
-        <trigger>
-            <expression>({Template EMC Unity REST-API v3:zabbix[host,,items_unsupported].last()})&gt;0</expression>
-            <recovery_mode>0</recovery_mode>
-            <recovery_expression/>
-            <name>{HOST.NAME} -&gt; Exist unsupported items</name>
-            <correlation_mode>0</correlation_mode>
-            <correlation_tag/>
-            <url/>
-            <status>0</status>
-            <priority>3</priority>
-            <description/>
-            <type>0</type>
-            <manual_close>0</manual_close>
-            <dependencies/>
-            <tags>
-                <tag>
-                    <tag>Department</tag>
-                    <value>MON.RTK</value>
-                </tag>
-            </tags>
-        </trigger>
-        <trigger>
-            <expression>{Template EMC Unity REST-API v3:unity_get_state.py[&quot;--api_ip={HOST.IP}&quot;,&quot;--api_port={$API_PORT}&quot;,&quot;--api_user={$API_USER}&quot;,&quot;--api_password={$API_PASSWORD}&quot;,&quot;--storage_name={HOST.NAME}&quot;,&quot;--status&quot;].nodata(3600)}=1</expression>
-            <recovery_mode>0</recovery_mode>
-            <recovery_expression/>
-            <name>{HOST.NAME} -&gt; No data from storage for 1 hours</name>
-            <correlation_mode>0</correlation_mode>
-            <correlation_tag/>
-            <url/>
-            <status>0</status>
-            <priority>4</priority>
-            <description/>
-            <type>0</type>
-            <manual_close>0</manual_close>
-            <dependencies/>
-            <tags>
-                <tag>
-                    <tag>Department</tag>
-                    <value>MON.RTK</value>
-                </tag>
-            </tags>
-        </trigger>
-    </triggers>
-    <value_maps>
-        <value_map>
-            <name>Unity_Health_Status</name>
-            <mappings>
-                <mapping>
-                    <value>0</value>
-                    <newvalue>UNKNOWN</newvalue>
-                </mapping>
-                <mapping>
-                    <value>5</value>
-                    <newvalue>OK</newvalue>
-                </mapping>
-                <mapping>
-                    <value>7</value>
-                    <newvalue>OK_BUT</newvalue>
-                </mapping>
-                <mapping>
-                    <value>10</value>
-                    <newvalue>DEGRADED</newvalue>
-                </mapping>
-                <mapping>
-                    <value>15</value>
-                    <newvalue>MINOR</newvalue>
-                </mapping>
-                <mapping>
-                    <value>20</value>
-                    <newvalue>MAJOR</newvalue>
-                </mapping>
-                <mapping>
-                    <value>25</value>
-                    <newvalue>CRITICAL</newvalue>
-                </mapping>
-                <mapping>
-                    <value>30</value>
-                    <newvalue>NON_RECOVERABLE</newvalue>
-                </mapping>
-            </mappings>
-        </value_map>
-        <value_map>
-            <name>Unity_Running_Status</name>
-            <mappings>
-                <mapping>
-                    <value>5</value>
-                    <newvalue>NOT_OK</newvalue>
-                </mapping>
-                <mapping>
-                    <value>6</value>
-                    <newvalue>DISK_SLOT_EMPTY</newvalue>
-                </mapping>
-                <mapping>
-                    <value>8</value>
-                    <newvalue>COMPONENT_OK</newvalue>
-                </mapping>
-                <mapping>
-                    <value>10</value>
-                    <newvalue>Link_up</newvalue>
-                </mapping>
-                <mapping>
-                    <value>11</value>
-                    <newvalue>Link_down</newvalue>
-                </mapping>
-            </mappings>
-        </value_map>
-    </value_maps>
-</zabbix_export>
+zabbix_export:
+  version: '5.4'
+  date: '2024-01-28T10:52:11Z'
+  groups:
+    -
+      uuid: 7df96b18c230490a9a0a9e2307226338
+      name: Templates
+  templates:
+    -
+      uuid: 482e80466d694a7e9dffcf708d029e2f
+      template: 'EMC Unity REST-API v3'
+      name: 'EMC Unity REST-API v3'
+      description: |
+        ## Overview
+        
+        Tested on Unity 600
+        
+        
+        Python-script to get metrics from EMC Unity Storage. Script uses REST-API interface.
+        
+        
+        This script get next metrics:
+        
+        
+        BBU, Disk, Disk Array Enclosure, Disk Processor Enclosure, FAN, I/O Module, LCC, Lun, Memory Module, Pool, PortEth, PortFibreChannel, PortSAS, PSU, SSC, SSD, Storage Processors, Uncommitted Port.
+      groups:
+        -
+          name: Templates
+      items:
+        -
+          uuid: ef286b876d7d402e9dba60887a8412df
+          name: 'get discovery'
+          type: EXTERNAL
+          key: 'unity_storage.py[discovery]'
+          delay: 15m
+          status: DISABLED
+          request_method: POST
+          tags:
+            -
+              tag: Application
+              value: get_data_from_script
+          triggers:
+            -
+              uuid: e5d7f486d858420da7d787d4e519e4c5
+              expression: 'count(/EMC Unity REST-API v3/unity_storage.py[discovery],30m,"le","2")>5'
+              name: '{HOST.NAME} -> Error occurs in getting metrics'
+              priority: HIGH
+        -
+          uuid: f8eba7376f3b4945b4428ad807203f97
+          name: 'get health state'
+          type: EXTERNAL
+          key: 'unity_storage.py[status]'
+          delay: 3m
+          status: DISABLED
+          request_method: POST
+          tags:
+            -
+              tag: Application
+              value: get_data_from_script
+          triggers:
+            -
+              uuid: 33d9a03afc86458e987bce8a50d12622
+              expression: 'count(/EMC Unity REST-API v3/unity_storage.py[status],30m,"ge","50")>5'
+              name: '{HOST.NAME} -> Error occurs in sending metrics'
+              priority: HIGH
+            -
+              uuid: 36db6860432441a5ac373ebb1aac7054
+              expression: 'nodata(/EMC Unity REST-API v3/unity_storage.py[status],3600s)=1'
+              name: '{HOST.NAME} -> No data from storage for 1 hours'
+              priority: HIGH
+        -
+          uuid: ac5e5e0a4b234aa1a9ed9d93791dcb84
+          name: 'Count of unsupported items'
+          type: INTERNAL
+          key: 'zabbix[host,,items_unsupported]'
+          delay: 5m
+          tags:
+            -
+              tag: Application
+              value: Internal
+          triggers:
+            -
+              uuid: 37fb77956df5455db0c5a5b1c53ebf06
+              expression: '(last(/EMC Unity REST-API v3/zabbix[host,,items_unsupported]))>0'
+              name: '{HOST.NAME} -> Exist unsupported items'
+              priority: AVERAGE
+      discovery_rules:
+        -
+          uuid: 21f9bfd5ac1449b8b638ef4716f84ad1
+          name: BBU
+          type: TRAP
+          key: battery
+          delay: '0'
+          lifetime: 1d
+          item_prototypes:
+            -
+              uuid: 4cafcbfa61c44b88836aa874e9a0fb71
+              name: 'Health status of BBU "{#ID}"'
+              type: TRAP
+              key: 'health.battery.[{#ID}]'
+              delay: '0'
+              valuemap:
+                name: Unity_Health_Status
+              request_method: POST
+              tags:
+                -
+                  tag: Application
+                  value: 'BBU health'
+              trigger_prototypes:
+                -
+                  uuid: b9582b70b8714e4eb95759b486c273c6
+                  expression: 'last(/EMC Unity REST-API v3/health.battery.[{#ID}])<>5'
+                  name: '{HOST.NAME} -> BBU "{#ID}" health status is {ITEM.VALUE}'
+                  priority: HIGH
+            -
+              uuid: 195979ad01f7412087a3a229994b59fb
+              name: 'Running status of BBU "{#ID}"'
+              type: TRAP
+              key: 'running.battery.[{#ID}]'
+              delay: '0'
+              valuemap:
+                name: Unity_Running_Status
+              request_method: POST
+              tags:
+                -
+                  tag: Application
+                  value: BBU
+              trigger_prototypes:
+                -
+                  uuid: 030b2a0231f6475cbbf31e2ed7c1649a
+                  expression: 'last(/EMC Unity REST-API v3/running.battery.[{#ID}])<>8'
+                  name: '{HOST.NAME} -> BBU "{#ID}" running status is {ITEM.VALUE}'
+                  priority: HIGH
+          request_method: POST
+        -
+          uuid: d17c7ad0f5a44f709d3e269bb8ca633e
+          name: 'Disk Array Enclosure (DAE)'
+          type: TRAP
+          key: dae
+          delay: '0'
+          lifetime: 1d
+          item_prototypes:
+            -
+              uuid: 63786cfdbc0f4f0e9978b8c701fc2aa8
+              name: 'Health status of DAE "{#ID}"'
+              type: TRAP
+              key: 'health.dae.[{#ID}]'
+              delay: '0'
+              valuemap:
+                name: Unity_Health_Status
+              request_method: POST
+              tags:
+                -
+                  tag: Application
+                  value: 'DAE health'
+              trigger_prototypes:
+                -
+                  uuid: 27d5478ab13044ce8e7af430cfd63f4a
+                  expression: 'last(/EMC Unity REST-API v3/health.dae.[{#ID}])<>5'
+                  name: '{HOST.NAME} -> DAE "{#ID}" health status is {ITEM.VALUE}'
+                  priority: HIGH
+            -
+              uuid: e551090b0b294546a9bda41e47f44d65
+              name: 'Running status of DAE "{#ID}"'
+              type: TRAP
+              key: 'running.dae.[{#ID}]'
+              delay: '0'
+              valuemap:
+                name: Unity_Running_Status
+              request_method: POST
+              tags:
+                -
+                  tag: Application
+                  value: 'DAE health'
+              trigger_prototypes:
+                -
+                  uuid: f1907f1cfbaa470bbd688a3f3272690b
+                  expression: 'last(/EMC Unity REST-API v3/running.dae.[{#ID}])<>8'
+                  name: '{HOST.NAME} -> DAE "{#ID}" running status is {ITEM.VALUE}'
+                  priority: HIGH
+          request_method: POST
+        -
+          uuid: f97e9422952141c9961f1ff2eeab17ac
+          name: Disk
+          type: TRAP
+          key: disk
+          delay: '0'
+          lifetime: 1d
+          item_prototypes:
+            -
+              uuid: 65ff832387af47b5a7829b03a52dd52e
+              name: 'Health status of disk "{#ID}"'
+              type: TRAP
+              key: 'health.disk.[{#ID}]'
+              delay: '0'
+              valuemap:
+                name: Unity_Health_Status
+              request_method: POST
+              tags:
+                -
+                  tag: Application
+                  value: 'Disk health'
+              trigger_prototypes:
+                -
+                  uuid: 6b6684443bb44882ba7ff7421e766eff
+                  expression: 'last(/EMC Unity REST-API v3/health.disk.[{#ID}])<>5'
+                  name: '{HOST.NAME} -> Hard disk "{#ID}" health status is {ITEM.VALUE}'
+                  priority: HIGH
+            -
+              uuid: d6779e6ab5a64ab8b243868c16495d71
+              name: 'Running status of disk "{#ID}"'
+              type: TRAP
+              key: 'running.disk.[{#ID}]'
+              delay: '0'
+              valuemap:
+                name: Unity_Running_Status
+              request_method: POST
+              tags:
+                -
+                  tag: Application
+                  value: Disk
+              trigger_prototypes:
+                -
+                  uuid: 4a74c68aaae1435c897b24d7cf8c8605
+                  expression: '({TRIGGER.VALUE}=0 and last(/EMC Unity REST-API v3/running.disk.[{#ID}])=6 and change(/EMC Unity REST-API v3/running.disk.[{#ID}])=1) or ({TRIGGER.VALUE}=1 and change(/EMC Unity REST-API v3/running.disk.[{#ID}])=0) or  ({TRIGGER.VALUE}=1 and last(/EMC Unity REST-API v3/running.disk.[{#ID}])<>8 and change(/EMC Unity REST-API v3/running.disk.[{#ID}])=1)'
+                  name: '{HOST.NAME} -> Hard disk "{#ID}" running status is {ITEM.VALUE}'
+                  priority: HIGH
+          request_method: POST
+        -
+          uuid: 56eacd3143a7479580d8a87fc13c143d
+          name: 'Disk Processor Enclosures (DPE)'
+          type: TRAP
+          key: dpe
+          delay: '0'
+          lifetime: 1d
+          item_prototypes:
+            -
+              uuid: 4eb7644e50fb4e4da28678542b187d18
+              name: 'Health status of DPE "{#ID}"'
+              type: TRAP
+              key: 'health.dpe.[{#ID}]'
+              delay: '0'
+              valuemap:
+                name: Unity_Health_Status
+              request_method: POST
+              tags:
+                -
+                  tag: Application
+                  value: 'DPE health'
+              trigger_prototypes:
+                -
+                  uuid: 44e035a3fd38457eb159d071a5fc688f
+                  expression: 'last(/EMC Unity REST-API v3/health.dpe.[{#ID}])<>5'
+                  name: '{HOST.NAME} -> DPE "{#ID}" health status is {ITEM.VALUE}'
+                  priority: HIGH
+            -
+              uuid: 6929e03415b5464e8bc9e84bf85a9eb2
+              name: 'Running status of DPE "{#ID}"'
+              type: TRAP
+              key: 'running.dpe.[{#ID}]'
+              delay: '0'
+              valuemap:
+                name: Unity_Running_Status
+              request_method: POST
+              tags:
+                -
+                  tag: Application
+                  value: 'DPE health'
+              trigger_prototypes:
+                -
+                  uuid: 8073a2628d6741a28f079329a38d8a3d
+                  expression: 'last(/EMC Unity REST-API v3/running.dpe.[{#ID}])<>8'
+                  name: '{HOST.NAME} -> DPE "{#ID}" running status is {ITEM.VALUE}'
+                  priority: HIGH
+          request_method: POST
+        -
+          uuid: a4fe462666d34e6186112b1008506f45
+          name: PortEth
+          type: TRAP
+          key: ethernetPort
+          delay: '0'
+          lifetime: 1d
+          item_prototypes:
+            -
+              uuid: 280a24c756d344428793513cbfc67d62
+              name: 'Health status of Ethernet port "{#ID}"'
+              type: TRAP
+              key: 'health.ethernetPort.[{#ID}]'
+              delay: '0'
+              valuemap:
+                name: Unity_Health_Status
+              request_method: POST
+              tags:
+                -
+                  tag: Application
+                  value: 'Eth health'
+              trigger_prototypes:
+                -
+                  uuid: 3abccaf053db447b89bd8bf65668b65e
+                  expression: 'last(/EMC Unity REST-API v3/health.ethernetPort.[{#ID}])<>5'
+                  name: '{HOST.NAME} -> Ethernet Port "{#ID}" health status is {ITEM.VALUE}'
+                  priority: HIGH
+            -
+              uuid: 9e23e7667a654c8aa37c303957b4ee60
+              name: 'Running status of Ethernet port "{#ID}"'
+              type: TRAP
+              key: 'link.ethernetPort.[{#ID}]'
+              delay: '0'
+              valuemap:
+                name: Unity_Running_Status
+              request_method: POST
+              tags:
+                -
+                  tag: Application
+                  value: Eth
+              trigger_prototypes:
+                -
+                  uuid: 7916533f0fb24ff09509d6a8d38b34ab
+                  expression: '({TRIGGER.VALUE}=0 and last(/EMC Unity REST-API v3/link.ethernetPort.[{#ID}])=11 and change(/EMC Unity REST-API v3/link.ethernetPort.[{#ID}])=1) or ({TRIGGER.VALUE}=1 and change(/EMC Unity REST-API v3/link.ethernetPort.[{#ID}])=0)'
+                  name: '{HOST.NAME} -> Ethernet Port "{#ID}" running status is {ITEM.VALUE}'
+                  priority: HIGH
+                  description: |
+                    Триггер настроен так, что те порты, которые имеют линк-даун (еще не введены в эксплуатацию) - по ним триггеров нет.
+                    Те порты, которые линк-ап (эксплуатириуются) - при смене состояния триггер загорается
+          request_method: POST
+        -
+          uuid: d325740b55964b6dbac5cd5154a204d0
+          name: FAN
+          type: TRAP
+          key: fan
+          delay: '0'
+          lifetime: 1d
+          item_prototypes:
+            -
+              uuid: 1b826dcb2f6343159da19c3442e9db6b
+              name: 'Health status of FAN "{#ID}"'
+              type: TRAP
+              key: 'health.fan.[{#ID}]'
+              delay: '0'
+              valuemap:
+                name: Unity_Health_Status
+              request_method: POST
+              tags:
+                -
+                  tag: Application
+                  value: 'FAN health'
+              trigger_prototypes:
+                -
+                  uuid: 9c58ea361d93419cbe1f1e074345d977
+                  expression: 'last(/EMC Unity REST-API v3/health.fan.[{#ID}])<>5'
+                  name: '{HOST.NAME} -> FAN "{#ID}" health status is {ITEM.VALUE}'
+                  priority: HIGH
+            -
+              uuid: 9d58e8e96f5046ea8b3941ac1b6ad52f
+              name: 'Running status of FAN "{#ID}"'
+              type: TRAP
+              key: 'running.fan.[{#ID}]'
+              delay: '0'
+              valuemap:
+                name: Unity_Running_Status
+              request_method: POST
+              tags:
+                -
+                  tag: Application
+                  value: FAN
+              trigger_prototypes:
+                -
+                  uuid: 53b44790f5c14179a65a4493c8127c91
+                  expression: 'last(/EMC Unity REST-API v3/running.fan.[{#ID}])<>8'
+                  name: '{HOST.NAME} -> FAN "{#ID}" running status is {ITEM.VALUE}'
+                  priority: HIGH
+          request_method: POST
+        -
+          uuid: 89e14678ef99404bb07ada469563d4de
+          name: PortFibreChannel
+          type: TRAP
+          key: fcPort
+          delay: '0'
+          lifetime: 1d
+          item_prototypes:
+            -
+              uuid: 165be738154948f48dae7941a1b25160
+              name: 'Health status of Fibre Channel port "{#ID}"'
+              type: TRAP
+              key: 'health.fcPort.[{#ID}]'
+              delay: '0'
+              valuemap:
+                name: Unity_Health_Status
+              request_method: POST
+              tags:
+                -
+                  tag: Application
+                  value: 'FC health'
+              trigger_prototypes:
+                -
+                  uuid: 5bd554ba5530410ab784fd5586a16c20
+                  expression: 'last(/EMC Unity REST-API v3/health.fcPort.[{#ID}])<>5'
+                  name: '{HOST.NAME} -> FibreChannel Port "{#ID}" health status is {ITEM.VALUE}'
+                  priority: HIGH
+            -
+              uuid: d0c59526a6b145478d22f9227adecd82
+              name: 'Running status of Fibre Channel port "{#ID}"'
+              type: TRAP
+              key: 'link.fcPort.[{#ID}]'
+              delay: '0'
+              valuemap:
+                name: Unity_Running_Status
+              request_method: POST
+              tags:
+                -
+                  tag: Application
+                  value: 'FC Port'
+              trigger_prototypes:
+                -
+                  uuid: f49e016ba1314bbcac0cc29894abca32
+                  expression: '({TRIGGER.VALUE}=0 and last(/EMC Unity REST-API v3/link.fcPort.[{#ID}])=11 and change(/EMC Unity REST-API v3/link.fcPort.[{#ID}])=1) or ({TRIGGER.VALUE}=1) and change(/EMC Unity REST-API v3/link.fcPort.[{#ID}])=0'
+                  name: '{HOST.NAME} -> FibreChannel Port "{#ID}" running status is {ITEM.VALUE}'
+                  priority: HIGH
+                  description: |
+                    Триггер настроен так, что те порты, которые имеют линк-даун (еще не введены в эксплуатацию) - по ним триггеров нет.
+                    Те порты, которые линк-ап (эксплуатириуются) - при смене состояния триггер загорается
+          request_method: POST
+        -
+          uuid: 59ef4519ff8a4517bfb2e010c5d587bb
+          name: 'I/O Module'
+          type: TRAP
+          key: ioModule
+          delay: '0'
+          lifetime: 1d
+          description: 'I/O modules provide connectivity between SPs and Disk-Array Enclosures (DAEs)'
+          item_prototypes:
+            -
+              uuid: d1b25ad799804ea8a2a47ee28b444104
+              name: 'Health status of ioModule "{#ID}"'
+              type: TRAP
+              key: 'health.ioModule.[{#ID}]'
+              delay: '0'
+              valuemap:
+                name: Unity_Health_Status
+              request_method: POST
+              tags:
+                -
+                  tag: Application
+                  value: 'I/O Module health'
+              trigger_prototypes:
+                -
+                  uuid: 3e2e78acc3dc4f078a7c41db91cf710c
+                  expression: 'last(/EMC Unity REST-API v3/health.ioModule.[{#ID}])<>5'
+                  name: '{HOST.NAME} -> ioModule "{#ID}" health status is {ITEM.VALUE}'
+                  priority: HIGH
+            -
+              uuid: 25163c20963b4751b4ca7e53ad994a9f
+              name: 'Running status of ioModule "{#ID}"'
+              type: TRAP
+              key: 'running.ioModule.[{#ID}]'
+              delay: '0'
+              valuemap:
+                name: Unity_Running_Status
+              request_method: POST
+              tags:
+                -
+                  tag: Application
+                  value: 'I/O Module health'
+              trigger_prototypes:
+                -
+                  uuid: b1dc65739e6542ceb9af59443df510a3
+                  expression: 'last(/EMC Unity REST-API v3/running.ioModule.[{#ID}])<>8'
+                  name: '{HOST.NAME} -> ioModule "{#ID}" running status is {ITEM.VALUE}'
+                  priority: HIGH
+          request_method: POST
+        -
+          uuid: f0bc98a999694f2faaa6872ce4183ef4
+          name: LCC
+          type: TRAP
+          key: lcc
+          delay: '0'
+          lifetime: 1d
+          description: 'Link Control Cards (LCCs)'
+          item_prototypes:
+            -
+              uuid: 4f8437b0f9254d949a6b81ccdda00d81
+              name: 'Health status of LLC "{#ID}"'
+              type: TRAP
+              key: 'health.lcc.[{#ID}]'
+              delay: '0'
+              valuemap:
+                name: Unity_Health_Status
+              request_method: POST
+              tags:
+                -
+                  tag: Application
+                  value: 'LCC health'
+              trigger_prototypes:
+                -
+                  uuid: 0bf7be4933ce4dd8ac28a6aa44cfc93a
+                  expression: 'last(/EMC Unity REST-API v3/health.lcc.[{#ID}])<>5'
+                  name: '{HOST.NAME} -> LCC "{#ID}" health status is {ITEM.VALUE}'
+                  priority: HIGH
+            -
+              uuid: 3c16630122ab480f9142a0236ef4fcca
+              name: 'Running status of LLC "{#ID}"'
+              type: TRAP
+              key: 'running.lcc.[{#ID}]'
+              delay: '0'
+              valuemap:
+                name: Unity_Running_Status
+              request_method: POST
+              tags:
+                -
+                  tag: Application
+                  value: 'LCC health'
+              trigger_prototypes:
+                -
+                  uuid: d83f35f0f9b44de3a5e03c9da289eeae
+                  expression: 'last(/EMC Unity REST-API v3/running.lcc.[{#ID}])<>8'
+                  name: '{HOST.NAME} -> LCC "{#ID}" running status is {ITEM.VALUE}'
+                  priority: HIGH
+          request_method: POST
+        -
+          uuid: 524fa75d3b604566a5908c8758bda69a
+          name: Lun
+          type: TRAP
+          key: lun
+          delay: '0'
+          lifetime: 1d
+          item_prototypes:
+            -
+              uuid: 7420490ee6a84066b158526a2a2db835
+              name: 'Health status of Lun "{#NAME}"'
+              type: TRAP
+              key: 'health.lun.[{#NAME}]'
+              delay: '0'
+              valuemap:
+                name: Unity_Health_Status
+              request_method: POST
+              tags:
+                -
+                  tag: Application
+                  value: 'LUN health'
+              trigger_prototypes:
+                -
+                  uuid: 83674672031b4f7c81a7cbe5af595ff9
+                  expression: 'last(/EMC Unity REST-API v3/health.lun.[{#NAME}])<>5'
+                  name: '{HOST.NAME} -> Lun "{#NAME}" health status is {ITEM.VALUE}'
+                  priority: HIGH
+            -
+              uuid: 2d2637caa9c44034a59fd822f9f630f3
+              name: 'Allocated size of Lun "{#NAME}"'
+              type: TRAP
+              key: 'sizeAllocated.lun.[{#NAME}]'
+              delay: '0'
+              units: B
+              description: |
+                Size of space actually allocated in the pool for the LUN:
+                         For thin-provisioned LUNs this as a rule is less than the sizeTotal attribute until the LUN is not fully populated with user data.
+                         For not thin-provisioned LUNs this is approximately equal to the sizeTotal.
+              tags:
+                -
+                  tag: Application
+                  value: LUN
+            -
+              uuid: 2df7c1c8cd1b403682b3d0b7f7c4b650
+              name: 'Total size of Lun "{#NAME}"'
+              type: TRAP
+              key: 'sizeTotal.lun.[{#NAME}]'
+              delay: '0'
+              units: B
+              description: 'LUN size that the system presents to the host or end user.'
+              tags:
+                -
+                  tag: Application
+                  value: LUN
+          request_method: POST
+        -
+          uuid: ea8aefc1659b4841911124c7841dd467
+          name: 'Memory Module'
+          type: TRAP
+          key: memoryModule
+          delay: '0'
+          lifetime: 1d
+          item_prototypes:
+            -
+              uuid: 6c1a7866ff294ddea713faf33c4dbac1
+              name: 'Health status of Memory Module "{#ID}"'
+              type: TRAP
+              key: 'health.memoryModule.[{#ID}]'
+              delay: '0'
+              valuemap:
+                name: Unity_Health_Status
+              request_method: POST
+              tags:
+                -
+                  tag: Application
+                  value: 'MemoryModule health'
+              trigger_prototypes:
+                -
+                  uuid: b851e0c6f4bf425c8e96eec261957a4c
+                  expression: 'last(/EMC Unity REST-API v3/health.memoryModule.[{#ID}])<>5'
+                  name: '{HOST.NAME} -> MemoryModule "{#ID}" health status is {ITEM.VALUE}'
+                  priority: HIGH
+            -
+              uuid: 1cb2d7778db04749bf319686eb466d23
+              name: 'Running status of Memory Module "{#ID}"'
+              type: TRAP
+              key: 'running.memoryModule.[{#ID}]'
+              delay: '0'
+              valuemap:
+                name: Unity_Running_Status
+              request_method: POST
+              tags:
+                -
+                  tag: Application
+                  value: Eth
+                -
+                  tag: Application
+                  value: MemoryModule
+              trigger_prototypes:
+                -
+                  uuid: df4d44353be04c6bbaeca48e308a9d5c
+                  expression: 'last(/EMC Unity REST-API v3/running.memoryModule.[{#ID}])<>8'
+                  name: '{HOST.NAME} -> MemoryModule "{#ID}" running status is {ITEM.VALUE}'
+                  priority: HIGH
+          request_method: POST
+        -
+          uuid: 365c1ece2053440c91e5176eebdb801f
+          name: Pool
+          type: TRAP
+          key: pool
+          delay: '0'
+          lifetime: 1d
+          item_prototypes:
+            -
+              uuid: 251aca52ca8f40668f0d5f67fcd38bff
+              name: 'Health status of Pool "{#NAME}"'
+              type: TRAP
+              key: 'health.pool.[{#NAME}]'
+              delay: '0'
+              valuemap:
+                name: Unity_Health_Status
+              request_method: POST
+              tags:
+                -
+                  tag: Application
+                  value: 'Pool health'
+              trigger_prototypes:
+                -
+                  uuid: deed8c5c6bad4a71bae55d96f157961d
+                  expression: 'last(/EMC Unity REST-API v3/health.pool.[{#NAME}])<>5'
+                  name: '{HOST.NAME} -> Pool "{#NAME}" health status is {ITEM.VALUE}'
+                  priority: HIGH
+            -
+              uuid: f029d2aaaac544b199ad6a72b7f9dbfd
+              name: 'Subscribed size of Pool "{#NAME}"'
+              type: TRAP
+              key: 'sizeSubscribedBytes.pool.[{#NAME}]'
+              delay: '0'
+              units: B
+              request_method: POST
+              tags:
+                -
+                  tag: Application
+                  value: Pool
+            -
+              uuid: 9a21fd0e0b8448d8aa81554db203ac94
+              name: 'Subscribed size of Pool "{#NAME}" in percent'
+              type: CALCULATED
+              key: 'sizeSubscribedPercent.pool.[{#NAME}]'
+              delay: 3m
+              value_type: FLOAT
+              units: '%'
+              params: '(100*last(//sizeSubscribedBytes.pool.[{#NAME}]))/last(//sizeTotalBytes.pool.[{#NAME}])'
+              request_method: POST
+              tags:
+                -
+                  tag: Application
+                  value: Pool
+              trigger_prototypes:
+                -
+                  uuid: 7d3ca49f40f94e1b8f236a2f8dbb0034
+                  expression: 'last(/EMC Unity REST-API v3/sizeSubscribedPercent.pool.[{#NAME}])>{$SUBSCRIBED_PERCENT:"{#NAME}"}'
+                  name: '{HOST.NAME} -> Subscribed capacity on pool "{#NAME}" > {$SUBSCRIBED_PERCENT:"{#NAME}"}%'
+                  priority: HIGH
+            -
+              uuid: cb3475bcf5ad4681a36568f5d1014595
+              name: 'Total size of Pool "{#NAME}"'
+              type: TRAP
+              key: 'sizeTotalBytes.pool.[{#NAME}]'
+              delay: '0'
+              units: B
+              request_method: POST
+              tags:
+                -
+                  tag: Application
+                  value: Pool
+            -
+              uuid: c67044c962f8475c82da00b3b7fffad1
+              name: 'Used size of Pool "{#NAME}"'
+              type: TRAP
+              key: 'sizeUsedBytes.pool.[{#NAME}]'
+              delay: '0'
+              units: B
+              request_method: POST
+              tags:
+                -
+                  tag: Application
+                  value: Pool
+            -
+              uuid: 48fd4a52e1034c9aa376693966e3b6bc
+              name: 'Used size of Pool "{#NAME}" in percent'
+              type: CALCULATED
+              key: 'sizeUsedPercent.pool.[{#NAME}]'
+              delay: 3m
+              value_type: FLOAT
+              units: '%'
+              params: '(100*last(//sizeUsedBytes.pool.[{#NAME}]))/last(//sizeTotalBytes.pool.[{#NAME}])'
+              request_method: POST
+              tags:
+                -
+                  tag: Application
+                  value: Pool
+              trigger_prototypes:
+                -
+                  uuid: fba86d86a5c54ad598389a9c9cb5a3cd
+                  expression: 'last(/EMC Unity REST-API v3/sizeUsedPercent.pool.[{#NAME}])>{$USED_PERCENT:"{#NAME}"}'
+                  name: '{HOST.NAME} -> Used capacity on pool "{#NAME}" > {$USED_PERCENT:"{#NAME}"}%'
+                  priority: HIGH
+          request_method: POST
+        -
+          uuid: 5a4f02dd733046169e319d1bb16abf05
+          name: PSU
+          type: TRAP
+          key: powerSupply
+          delay: '0'
+          lifetime: 1d
+          item_prototypes:
+            -
+              uuid: ec30e53abf4549949366666e3bd99cba
+              name: 'Health status of PSU "{#ID}"'
+              type: TRAP
+              key: 'health.powerSupply.[{#ID}]'
+              delay: '0'
+              valuemap:
+                name: Unity_Health_Status
+              request_method: POST
+              tags:
+                -
+                  tag: Application
+                  value: 'PSU health'
+              trigger_prototypes:
+                -
+                  uuid: c012b2392dbc4fd3835d795395190bcb
+                  expression: 'last(/EMC Unity REST-API v3/health.powerSupply.[{#ID}])<>5'
+                  name: '{HOST.NAME} -> PSU "{#ID}" health status is {ITEM.VALUE}'
+                  priority: HIGH
+            -
+              uuid: 08ea258a60654411805ad0abb870a429
+              name: 'Running status of PSU "{#ID}"'
+              type: TRAP
+              key: 'running.powerSupply.[{#ID}]'
+              delay: '0'
+              valuemap:
+                name: Unity_Running_Status
+              request_method: POST
+              tags:
+                -
+                  tag: Application
+                  value: PSU
+              trigger_prototypes:
+                -
+                  uuid: d9b55e5af7614329b1de41b2a8523ee0
+                  expression: 'last(/EMC Unity REST-API v3/running.powerSupply.[{#ID}])<>8'
+                  name: '{HOST.NAME} -> PSU "{#ID}" running status is {ITEM.VALUE}'
+                  priority: HIGH
+          request_method: POST
+        -
+          uuid: 78b39473510a4bdbba85c66ff84d84fa
+          name: PortSAS
+          type: TRAP
+          key: sasPort
+          delay: '0'
+          lifetime: 1d
+          item_prototypes:
+            -
+              uuid: 47f0e90e04b34318825af3b33f811afc
+              name: 'Health status of SAS port "{#ID}"'
+              type: TRAP
+              key: 'health.sasPort.[{#ID}]'
+              delay: '0'
+              valuemap:
+                name: Unity_Health_Status
+              request_method: POST
+              tags:
+                -
+                  tag: Application
+                  value: 'SAS health'
+              trigger_prototypes:
+                -
+                  uuid: 6db5346b184a4811998af44ed1df601b
+                  expression: 'last(/EMC Unity REST-API v3/health.sasPort.[{#ID}])<>5'
+                  name: '{HOST.NAME} -> SAS Port "{#ID}" health status is {ITEM.VALUE}'
+                  priority: HIGH
+            -
+              uuid: ebc8dedad6624af7a44e4d123a8ae107
+              name: 'Running status of SAS port "{#ID}"'
+              type: TRAP
+              key: 'link.sasPort.[{#ID}]'
+              delay: '0'
+              valuemap:
+                name: Unity_Running_Status
+              request_method: POST
+              tags:
+                -
+                  tag: Application
+                  value: SAS
+              trigger_prototypes:
+                -
+                  uuid: 912885b9363c4f839b67f0bda603b8df
+                  expression: '({TRIGGER.VALUE}=0 and last(/EMC Unity REST-API v3/link.sasPort.[{#ID}])=11 and change(/EMC Unity REST-API v3/link.sasPort.[{#ID}])=1) or ({TRIGGER.VALUE}=1 and change(/EMC Unity REST-API v3/link.sasPort.[{#ID}])=0)'
+                  name: '{HOST.NAME} -> SAS Port "{#ID}" running status is {ITEM.VALUE}'
+                  priority: HIGH
+                  description: |
+                    Триггер настроен так, что те порты, которые имеют линк-даун (еще не введены в эксплуатацию) - по ним триггеров нет.
+                    Те порты, которые линк-ап (эксплуатириуются) - при смене состояния триггер загорается
+          request_method: POST
+        -
+          uuid: 5d607bce3a664f728f0a0bac6beb6d22
+          name: SSC
+          type: TRAP
+          key: ssc
+          delay: '0'
+          lifetime: 1d
+          description: 'System Status Cards (SSCs)'
+          item_prototypes:
+            -
+              uuid: 8f0e830e6e65409ebc7b9a72459446f6
+              name: 'Health status of SSC "{#ID}"'
+              type: TRAP
+              key: 'health.ssc.[{#ID}]'
+              delay: '0'
+              valuemap:
+                name: Unity_Health_Status
+              request_method: POST
+              tags:
+                -
+                  tag: Application
+                  value: 'SSC health'
+              trigger_prototypes:
+                -
+                  uuid: 5cef504dcab54c87a8610957948ddcfb
+                  expression: 'last(/EMC Unity REST-API v3/health.ssc.[{#ID}])<>5'
+                  name: '{HOST.NAME} -> SSC "{#ID}" health status is {ITEM.VALUE}'
+                  priority: HIGH
+            -
+              uuid: 9825b80c6be642ea9a964fc6b6523d92
+              name: 'Running status of SSC "{#ID}"'
+              type: TRAP
+              key: 'running.ssc.[{#ID}]'
+              delay: '0'
+              valuemap:
+                name: Unity_Running_Status
+              request_method: POST
+              tags:
+                -
+                  tag: Application
+                  value: 'SSC health'
+              trigger_prototypes:
+                -
+                  uuid: 8d4d3edbf3d7497081dba02f43dbcea7
+                  expression: 'last(/EMC Unity REST-API v3/running.ssc.[{#ID}])<>8'
+                  name: '{HOST.NAME} -> SSC "{#ID}" running status is {ITEM.VALUE}'
+                  priority: HIGH
+          request_method: POST
+        -
+          uuid: 548684a2a507433392006ded156dca9f
+          name: SSD
+          type: TRAP
+          key: ssd
+          delay: '0'
+          lifetime: 1d
+          item_prototypes:
+            -
+              uuid: c20b537d0eb74c3d85e6a34e4b064863
+              name: 'Health status of SSD "{#ID}"'
+              type: TRAP
+              key: 'health.ssd.[{#ID}]'
+              delay: '0'
+              valuemap:
+                name: Unity_Health_Status
+              request_method: POST
+              tags:
+                -
+                  tag: Application
+                  value: 'SSD health'
+              trigger_prototypes:
+                -
+                  uuid: f832630cd02345cc96e7f757f3a77413
+                  expression: 'last(/EMC Unity REST-API v3/health.ssd.[{#ID}])<>5'
+                  name: '{HOST.NAME} -> SSD "{#ID}" health status is {ITEM.VALUE}'
+                  priority: HIGH
+            -
+              uuid: d9fee9ca0579465998210b6555d3d715
+              name: 'Running status of SSD "{#ID}"'
+              type: TRAP
+              key: 'running.ssd.[{#ID}]'
+              delay: '0'
+              valuemap:
+                name: Unity_Running_Status
+              request_method: POST
+              tags:
+                -
+                  tag: Application
+                  value: 'SSD health'
+              trigger_prototypes:
+                -
+                  uuid: 41b0832d38c340b096f8176f459bbd7b
+                  expression: 'last(/EMC Unity REST-API v3/running.ssd.[{#ID}])<>8'
+                  name: '{HOST.NAME} -> SSD "{#ID}" running status is {ITEM.VALUE}'
+                  priority: HIGH
+          request_method: POST
+        -
+          uuid: 6e4e0f6d7eb040fcbdd93dfa1ed0e02e
+          name: 'Storage Processors'
+          type: TRAP
+          key: storageProcessor
+          delay: '0'
+          lifetime: 1d
+          item_prototypes:
+            -
+              uuid: f3e11a9514254985bbe1315a266b9d2d
+              name: 'Health status of Storage Processors "{#ID}"'
+              type: TRAP
+              key: 'health.storageProcessor.[{#ID}]'
+              delay: '0'
+              valuemap:
+                name: Unity_Health_Status
+              request_method: POST
+              tags:
+                -
+                  tag: Application
+                  value: 'StorageProcessor health'
+              trigger_prototypes:
+                -
+                  uuid: a6c1cb011acf4f79ac63a871ca5c9d6b
+                  expression: 'last(/EMC Unity REST-API v3/health.storageProcessor.[{#ID}])<>5'
+                  name: '{HOST.NAME} -> Storage Processor "{#ID}" health status is {ITEM.VALUE}'
+                  priority: HIGH
+            -
+              uuid: 647ef1a08ee640829fb835b0425ff627
+              name: 'Running status of Storage Processors "{#ID}"'
+              type: TRAP
+              key: 'running.storageProcessor.[{#ID}]'
+              delay: '0'
+              valuemap:
+                name: Unity_Running_Status
+              request_method: POST
+              tags:
+                -
+                  tag: Application
+                  value: 'StorageProcessor health'
+              trigger_prototypes:
+                -
+                  uuid: bdb922404da544dfb8f66304b55880a0
+                  expression: 'last(/EMC Unity REST-API v3/running.storageProcessor.[{#ID}])<>8'
+                  name: '{HOST.NAME} -> Storage Processor "{#ID}" running status is {ITEM.VALUE}'
+                  priority: HIGH
+          request_method: POST
+        -
+          uuid: 590576c9d1c94360bd9245d2f3030e01
+          name: 'Uncommitted Port'
+          type: TRAP
+          key: uncommittedPort
+          delay: '0'
+          lifetime: 1d
+          item_prototypes:
+            -
+              uuid: f29d1cee12d3418f86924fb1434b05d1
+              name: 'Health status of Uncommitted Port "{#ID}"'
+              type: TRAP
+              key: 'health.uncommittedPort.[{#ID}]'
+              delay: '0'
+              valuemap:
+                name: Unity_Health_Status
+              request_method: POST
+              tags:
+                -
+                  tag: Application
+                  value: 'Uncommitted Port health'
+              trigger_prototypes:
+                -
+                  uuid: 76460cbed93a4688a4944512bd4b96c7
+                  expression: 'last(/EMC Unity REST-API v3/health.uncommittedPort.[{#ID}])<>5'
+                  name: '{HOST.NAME} -> Uncommited Port "{#ID}" health status is {ITEM.VALUE}'
+                  priority: HIGH
+            -
+              uuid: 5c308b53b1c84dbca4ef433997d116ca
+              name: 'Running status of Uncommitted Port "{#ID}"'
+              type: TRAP
+              key: 'running.uncommittedPort.[{#ID}]'
+              delay: '0'
+              valuemap:
+                name: Unity_Running_Status
+              request_method: POST
+              tags:
+                -
+                  tag: Application
+                  value: 'Uncommitted Port health'
+              trigger_prototypes:
+                -
+                  uuid: e00cdb798fcd4479bc927288ad485518
+                  expression: 'last(/EMC Unity REST-API v3/running.uncommittedPort.[{#ID}])<>8'
+                  name: '{HOST.NAME} -> Uncommited Port "{#ID}" running status is {ITEM.VALUE}'
+                  priority: HIGH
+          request_method: POST
+      macros:
+        -
+          macro: '{$API_PASSWORD}'
+        -
+          macro: '{$API_PORT}'
+          value: '443'
+        -
+          macro: '{$API_USER}'
+        -
+          macro: '{$SUBSCRIBED_PERCENT}'
+          value: '91'
+        -
+          macro: '{$USED_PERCENT}'
+          value: '91'
+      valuemaps:
+        -
+          uuid: d24dc0fffb004b0ebc9270ed88ab7e07
+          name: Unity_Health_Status
+          mappings:
+            -
+              value: '0'
+              newvalue: UNKNOWN
+            -
+              value: '5'
+              newvalue: OK
+            -
+              value: '7'
+              newvalue: OK_BUT
+            -
+              value: '10'
+              newvalue: DEGRADED
+            -
+              value: '15'
+              newvalue: MINOR
+            -
+              value: '20'
+              newvalue: MAJOR
+            -
+              value: '25'
+              newvalue: CRITICAL
+            -
+              value: '30'
+              newvalue: NON_RECOVERABLE
+        -
+          uuid: 2513762d02e94b27bac71c518d215b1c
+          name: Unity_Running_Status
+          mappings:
+            -
+              value: '5'
+              newvalue: NOT_OK
+            -
+              value: '6'
+              newvalue: DISK_SLOT_EMPTY
+            -
+              value: '8'
+              newvalue: COMPONENT_OK
+            -
+              value: '10'
+              newvalue: Link_up
+            -
+              value: '11'
+              newvalue: Link_down


### PR DESCRIPTION
I have modified the code to utilize Pyzabbix for sending data to Zabbix, replacing the previous use of Zabbix sender. Additionally, this updated code incorporates internal authentication mechanisms instead of relying on Zabbix parameters for data retrieval. zabbix-emc-unity

Python script designed for monitoring EMC Unity storages